### PR TITLE
Add enhanced evaluation with quality metrics and structured suggestions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ ignore = []
 [tool.ruff.lint.isort]
 known-first-party = ["mcprobe"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["PLR2004"]  # Allow magic values in tests for clarity
+
 [tool.mypy]
 python_version = "3.11"
 strict = true
@@ -109,6 +112,10 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "mcprobe.agents.adk"
 disallow_untyped_calls = false
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disable_error_code = ["method-assign"]
 
 [tool.pydantic-mypy]
 init_forbid_extra = true

--- a/src/mcprobe/cli/main.py
+++ b/src/mcprobe/cli/main.py
@@ -291,6 +291,32 @@ def _display_verbose_results(
         status = "[red]TRIGGERED[/red]" if triggered else "[green]OK[/green]"
         console.print(f"  {criterion}: {status}")
 
+    console.print("\n[bold]Quality Metrics:[/bold]")
+    qm = judgment_result.quality_metrics
+    console.print(f"  Clarifications: {qm.clarification_count}")
+    console.print(f"  Backtracks: {qm.backtrack_count}")
+    console.print(f"  Turns to first answer: {qm.turns_to_first_answer}")
+    console.print(f"  Answer completeness: {qm.final_answer_completeness:.0%}")
+
+    console.print("\n[bold]Efficiency:[/bold]")
+    eff = judgment_result.efficiency_results
+    console.print(f"  Total tokens: {eff.get('total_tokens', 0)}")
+    console.print(f"  Tool calls: {eff.get('total_tool_calls', 0)}")
+    console.print(f"  Turns: {eff.get('total_turns', 0)}")
+
+    if judgment_result.structured_suggestions:
+        console.print("\n[bold]MCP Improvement Suggestions:[/bold]")
+        for s in judgment_result.structured_suggestions:
+            severity_color = {"low": "blue", "medium": "yellow", "high": "red"}.get(
+                s.severity.value, "white"
+            )
+            console.print(
+                f"  [{severity_color}][{s.severity.value}][/{severity_color}] "
+                f"{s.category.value}: {s.tool_name or 'general'}"
+            )
+            console.print(f"    Issue: {s.issue}")
+            console.print(f"    Suggestion: {s.suggestion}")
+
 
 def _display_summary(results: list[tuple[str, bool, float]]) -> None:
     """Display summary of all scenario results.

--- a/src/mcprobe/models/conversation.py
+++ b/src/mcprobe/models/conversation.py
@@ -33,6 +33,7 @@ class UserResponse(BaseModel):
 
     message: str
     is_satisfied: bool = False
+    tokens_used: int = 0
 
 
 class ConversationTurn(BaseModel):

--- a/src/mcprobe/models/judgment.py
+++ b/src/mcprobe/models/judgment.py
@@ -3,9 +3,46 @@
 Defines the structure for evaluation results from the judge LLM.
 """
 
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+
+class SuggestionCategory(str, Enum):
+    """Category of MCP server improvement suggestion."""
+
+    DESCRIPTION = "description"
+    PARAMETER = "parameter"
+    RETURN_VALUE = "return_value"
+    SCHEMA = "schema"
+
+
+class SuggestionSeverity(str, Enum):
+    """Severity level of an improvement suggestion."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class QualityMetrics(BaseModel):
+    """Conversation quality measurements."""
+
+    clarification_count: int = 0
+    backtrack_count: int = 0
+    turns_to_first_answer: int = 0
+    final_answer_completeness: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class MCPSuggestion(BaseModel):
+    """Structured suggestion for MCP server improvement."""
+
+    category: SuggestionCategory
+    tool_name: str | None = None
+    issue: str
+    suggestion: str
+    severity: SuggestionSeverity = SuggestionSeverity.MEDIUM
 
 
 class JudgmentResult(BaseModel):
@@ -19,3 +56,5 @@ class JudgmentResult(BaseModel):
     efficiency_results: dict[str, Any]
     reasoning: str
     suggestions: list[str] = Field(default_factory=list)
+    quality_metrics: QualityMetrics = Field(default_factory=QualityMetrics)
+    structured_suggestions: list[MCPSuggestion] = Field(default_factory=list)

--- a/src/mcprobe/orchestrator/orchestrator.py
+++ b/src/mcprobe/orchestrator/orchestrator.py
@@ -82,6 +82,7 @@ class ConversationOrchestrator:
         start_time = time.time()
         turns: list[ConversationTurn] = []
         all_tool_calls: list[ToolCall] = []
+        total_tokens = 0
         max_turns = scenario.synthetic_user.max_turns
         termination_reason = TerminationReason.MAX_TURNS
         final_answer = ""
@@ -138,6 +139,9 @@ class ConversationOrchestrator:
                 msg = f"Synthetic user failed to respond: {e}"
                 raise OrchestrationError(msg) from e
 
+            # Aggregate token usage from synthetic user
+            total_tokens += user_response.tokens_used
+
             # Check if user is satisfied
             if user_response.is_satisfied:
                 final_answer = agent_response.message
@@ -184,7 +188,7 @@ class ConversationOrchestrator:
             turns=turns,
             final_answer=final_answer,
             total_tool_calls=all_tool_calls,
-            total_tokens=0,  # Would need token counting from providers
+            total_tokens=total_tokens,
             duration_seconds=duration,
             termination_reason=termination_reason,
         )

--- a/tests/integration/test_phase3_evaluation.py
+++ b/tests/integration/test_phase3_evaluation.py
@@ -1,0 +1,368 @@
+"""Integration tests for Phase 3 enhanced evaluation features."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcprobe.judge.judge import (
+    ConversationJudge,
+    JudgeEvaluation,
+    JudgeQualityMetrics,
+    JudgeStructuredSuggestion,
+)
+from mcprobe.models.conversation import (
+    ConversationResult,
+    ConversationTurn,
+    TerminationReason,
+    ToolCall,
+)
+from mcprobe.models.judgment import SuggestionCategory, SuggestionSeverity
+from mcprobe.models.scenario import (
+    ClarificationBehavior,
+    EfficiencyConfig,
+    EvaluationConfig,
+    SyntheticUserConfig,
+    TestScenario,
+    ToolCallCriterion,
+    ToolUsageConfig,
+)
+from mcprobe.providers.base import LLMProvider
+
+
+@pytest.fixture
+def mock_provider() -> LLMProvider:
+    """Create a mock LLM provider."""
+    provider = AsyncMock(spec=LLMProvider)
+    return provider
+
+
+@pytest.fixture
+def sample_scenario() -> TestScenario:
+    """Create a sample test scenario with tool call criteria."""
+    return TestScenario(
+        name="Weather Query Test",
+        description="Test weather tool usage",
+        synthetic_user=SyntheticUserConfig(
+            persona="A user planning a trip to Phoenix",
+            initial_query="What's the weather in Phoenix for the next week?",
+            clarification_behavior=ClarificationBehavior(),
+            max_turns=5,
+        ),
+        evaluation=EvaluationConfig(
+            correctness_criteria=[
+                "Provides weather forecast for Phoenix",
+                "Includes temperature information",
+            ],
+            failure_criteria=[
+                "Provides weather for wrong city",
+            ],
+            tool_usage=ToolUsageConfig(
+                required_tools=["get_weather_forecast"],
+                prohibited_tools=["delete_data"],
+                tool_call_criteria=[
+                    ToolCallCriterion(
+                        tool="get_weather_forecast",
+                        assertions=[
+                            "location parameter includes Phoenix",
+                            "forecast_days >= 5",
+                        ],
+                    ),
+                ],
+            ),
+            efficiency=EfficiencyConfig(
+                max_tool_calls=3,
+                max_conversation_turns=5,
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def sample_conversation_result() -> ConversationResult:
+    """Create a sample conversation result with tool calls and tokens."""
+    return ConversationResult(
+        turns=[
+            ConversationTurn(
+                role="user",
+                content="What's the weather in Phoenix for the next week?",
+                tool_calls=[],
+                timestamp=1000.0,
+            ),
+            ConversationTurn(
+                role="assistant",
+                content="Let me check the weather forecast for Phoenix.",
+                tool_calls=[
+                    ToolCall(
+                        tool_name="get_weather_forecast",
+                        parameters={"location": "Phoenix, AZ", "forecast_days": 7},
+                        result={"forecast": [{"day": 1, "temp": 95}]},
+                        latency_ms=150.0,
+                    ),
+                ],
+                timestamp=1001.0,
+            ),
+            ConversationTurn(
+                role="assistant",
+                content="The weather in Phoenix for the next week shows temperatures around 95°F.",
+                tool_calls=[],
+                timestamp=1002.0,
+            ),
+            ConversationTurn(
+                role="user",
+                content="Thanks, that's helpful!",
+                tool_calls=[],
+                timestamp=1003.0,
+            ),
+        ],
+        final_answer="The weather in Phoenix for the next week shows temperatures around 95°F.",
+        total_tool_calls=[
+            ToolCall(
+                tool_name="get_weather_forecast",
+                parameters={"location": "Phoenix, AZ", "forecast_days": 7},
+                result={"forecast": [{"day": 1, "temp": 95}]},
+                latency_ms=150.0,
+            ),
+        ],
+        total_tokens=450,
+        duration_seconds=3.5,
+        termination_reason=TerminationReason.USER_SATISFIED,
+    )
+
+
+class TestJudgeEvaluationPhase3:
+    """Tests for Phase 3 judge evaluation features."""
+
+    @pytest.mark.asyncio
+    async def test_judge_returns_quality_metrics(
+        self,
+        mock_provider: LLMProvider,
+        sample_scenario: TestScenario,
+        sample_conversation_result: ConversationResult,
+    ) -> None:
+        """Test that judge evaluation includes quality metrics."""
+        # Set up mock to return evaluation with quality metrics
+        mock_evaluation = JudgeEvaluation(
+            passed=True,
+            score=0.9,
+            correctness_results={
+                "Provides weather forecast for Phoenix": True,
+                "Includes temperature information": True,
+            },
+            failure_results={
+                "Provides weather for wrong city": False,
+            },
+            tool_usage_results={
+                "required_tools_used": ["get_weather_forecast"],
+                "prohibited_tools_used": [],
+                "all_required_used": True,
+                "no_prohibited_used": True,
+                "criteria_results": {
+                    "get_weather_forecast": {
+                        "location parameter includes Phoenix": True,
+                        "forecast_days >= 5": True,
+                    }
+                },
+            },
+            efficiency_results={
+                "tool_calls": 1,
+                "conversation_turns": 4,
+                "within_limits": True,
+            },
+            reasoning="Agent successfully retrieved weather forecast",
+            suggestions=["Consider showing multiple days"],
+            quality_metrics=JudgeQualityMetrics(
+                clarification_count=0,
+                backtrack_count=0,
+                turns_to_first_answer=2,
+                final_answer_completeness=0.9,
+            ),
+            structured_suggestions=[],
+        )
+
+        mock_provider.generate_structured = AsyncMock(return_value=mock_evaluation)
+
+        judge = ConversationJudge(mock_provider)
+        result = await judge.evaluate(sample_scenario, sample_conversation_result)
+
+        # Verify quality metrics are in result
+        assert result.quality_metrics.clarification_count == 0
+        assert result.quality_metrics.backtrack_count == 0
+        assert result.quality_metrics.turns_to_first_answer == 2
+        assert result.quality_metrics.final_answer_completeness == 0.9
+
+    @pytest.mark.asyncio
+    async def test_judge_returns_structured_suggestions(
+        self,
+        mock_provider: LLMProvider,
+        sample_scenario: TestScenario,
+        sample_conversation_result: ConversationResult,
+    ) -> None:
+        """Test that judge evaluation includes structured suggestions."""
+        mock_evaluation = JudgeEvaluation(
+            passed=True,
+            score=0.85,
+            correctness_results={"criterion": True},
+            failure_results={},
+            tool_usage_results={
+                "required_tools_used": ["get_weather_forecast"],
+                "prohibited_tools_used": [],
+                "all_required_used": True,
+                "no_prohibited_used": True,
+            },
+            efficiency_results={"within_limits": True},
+            reasoning="Good but could improve",
+            suggestions=["Add more days"],
+            quality_metrics=JudgeQualityMetrics(),
+            structured_suggestions=[
+                JudgeStructuredSuggestion(
+                    category="parameter",
+                    tool_name="get_weather_forecast",
+                    issue="Default forecast_days not documented",
+                    suggestion="Add default value to parameter description",
+                    severity="low",
+                ),
+                JudgeStructuredSuggestion(
+                    category="return_value",
+                    tool_name="get_weather_forecast",
+                    issue="Temperature units not specified",
+                    suggestion="Document whether temp is in Celsius or Fahrenheit",
+                    severity="medium",
+                ),
+            ],
+        )
+
+        mock_provider.generate_structured = AsyncMock(return_value=mock_evaluation)
+
+        judge = ConversationJudge(mock_provider)
+        result = await judge.evaluate(sample_scenario, sample_conversation_result)
+
+        # Verify structured suggestions
+        assert len(result.structured_suggestions) == 2
+
+        # First suggestion
+        assert result.structured_suggestions[0].category == SuggestionCategory.PARAMETER
+        assert result.structured_suggestions[0].tool_name == "get_weather_forecast"
+        assert result.structured_suggestions[0].severity == SuggestionSeverity.LOW
+
+        # Second suggestion
+        assert result.structured_suggestions[1].category == SuggestionCategory.RETURN_VALUE
+        assert result.structured_suggestions[1].severity == SuggestionSeverity.MEDIUM
+
+    @pytest.mark.asyncio
+    async def test_judge_includes_token_count_in_efficiency(
+        self,
+        mock_provider: LLMProvider,
+        sample_scenario: TestScenario,
+        sample_conversation_result: ConversationResult,
+    ) -> None:
+        """Test that efficiency results include token count from conversation."""
+        mock_evaluation = JudgeEvaluation(
+            passed=True,
+            score=0.9,
+            correctness_results={},
+            failure_results={},
+            tool_usage_results={
+                "required_tools_used": [],
+                "all_required_used": True,
+                "no_prohibited_used": True,
+            },
+            efficiency_results={"within_limits": True},
+            reasoning="Efficient",
+            suggestions=[],
+            quality_metrics=JudgeQualityMetrics(),
+            structured_suggestions=[],
+        )
+
+        mock_provider.generate_structured = AsyncMock(return_value=mock_evaluation)
+
+        judge = ConversationJudge(mock_provider)
+        result = await judge.evaluate(sample_scenario, sample_conversation_result)
+
+        # Verify token count is included from conversation result
+        assert result.efficiency_results["total_tokens"] == 450
+
+    @pytest.mark.asyncio
+    async def test_judge_includes_criteria_results(
+        self,
+        mock_provider: LLMProvider,
+        sample_scenario: TestScenario,
+        sample_conversation_result: ConversationResult,
+    ) -> None:
+        """Test that tool usage includes criteria evaluation results."""
+        mock_evaluation = JudgeEvaluation(
+            passed=True,
+            score=0.85,
+            correctness_results={},
+            failure_results={},
+            tool_usage_results={
+                "required_tools_used": ["get_weather_forecast"],
+                "prohibited_tools_used": [],
+                "all_required_used": True,
+                "no_prohibited_used": True,
+                "criteria_results": {
+                    "get_weather_forecast": {
+                        "location parameter includes Phoenix": True,
+                        "forecast_days >= 5": False,  # Criterion not met
+                    }
+                },
+            },
+            efficiency_results={"within_limits": True},
+            reasoning="Tool used but criteria partially met",
+            suggestions=[],
+            quality_metrics=JudgeQualityMetrics(),
+            structured_suggestions=[],
+        )
+
+        mock_provider.generate_structured = AsyncMock(return_value=mock_evaluation)
+
+        judge = ConversationJudge(mock_provider)
+        result = await judge.evaluate(sample_scenario, sample_conversation_result)
+
+        # Verify criteria results are preserved
+        criteria_results = result.tool_usage_results.get("criteria_results", {})
+        assert "get_weather_forecast" in criteria_results
+        assert criteria_results["get_weather_forecast"]["location parameter includes Phoenix"]
+        assert not criteria_results["get_weather_forecast"]["forecast_days >= 5"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_category_falls_back_to_default(
+        self,
+        mock_provider: LLMProvider,
+        sample_scenario: TestScenario,
+        sample_conversation_result: ConversationResult,
+    ) -> None:
+        """Test that invalid suggestion category falls back to DESCRIPTION."""
+        mock_evaluation = JudgeEvaluation(
+            passed=True,
+            score=0.9,
+            correctness_results={},
+            failure_results={},
+            tool_usage_results={
+                "required_tools_used": [],
+                "all_required_used": True,
+                "no_prohibited_used": True,
+            },
+            efficiency_results={"within_limits": True},
+            reasoning="OK",
+            suggestions=[],
+            quality_metrics=JudgeQualityMetrics(),
+            structured_suggestions=[
+                JudgeStructuredSuggestion(
+                    category="invalid_category",  # Invalid category
+                    tool_name=None,
+                    issue="Some issue",
+                    suggestion="Some fix",
+                    severity="invalid_severity",  # Invalid severity
+                ),
+            ],
+        )
+
+        mock_provider.generate_structured = AsyncMock(return_value=mock_evaluation)
+
+        judge = ConversationJudge(mock_provider)
+        result = await judge.evaluate(sample_scenario, sample_conversation_result)
+
+        # Should fall back to defaults
+        assert len(result.structured_suggestions) == 1
+        assert result.structured_suggestions[0].category == SuggestionCategory.DESCRIPTION
+        assert result.structured_suggestions[0].severity == SuggestionSeverity.MEDIUM

--- a/tests/unit/test_conversation_models.py
+++ b/tests/unit/test_conversation_models.py
@@ -1,0 +1,141 @@
+"""Tests for conversation data models."""
+
+from mcprobe.models.conversation import (
+    AgentResponse,
+    ConversationResult,
+    ConversationTurn,
+    TerminationReason,
+    ToolCall,
+    UserResponse,
+)
+
+
+class TestUserResponse:
+    """Tests for UserResponse model."""
+
+    def test_default_tokens(self) -> None:
+        """Test UserResponse has default tokens_used of 0."""
+        response = UserResponse(message="Hello", is_satisfied=False)
+
+        assert response.tokens_used == 0
+
+    def test_with_tokens(self) -> None:
+        """Test UserResponse with token count."""
+        response = UserResponse(
+            message="Thanks, that helps!",
+            is_satisfied=True,
+            tokens_used=150,
+        )
+
+        assert response.message == "Thanks, that helps!"
+        assert response.is_satisfied is True
+        assert response.tokens_used == 150
+
+
+class TestToolCall:
+    """Tests for ToolCall model."""
+
+    def test_successful_call(self) -> None:
+        """Test ToolCall for successful invocation."""
+        call = ToolCall(
+            tool_name="get_weather",
+            parameters={"location": "Phoenix"},
+            result={"temp": 95, "conditions": "sunny"},
+            latency_ms=150.5,
+        )
+
+        assert call.tool_name == "get_weather"
+        assert call.parameters == {"location": "Phoenix"}
+        assert call.result["temp"] == 95
+        assert call.latency_ms == 150.5
+        assert call.error is None
+
+    def test_failed_call(self) -> None:
+        """Test ToolCall with error."""
+        call = ToolCall(
+            tool_name="get_weather",
+            parameters={"location": "invalid"},
+            result=None,
+            latency_ms=50.0,
+            error="Location not found",
+        )
+
+        assert call.error == "Location not found"
+        assert call.result is None
+
+
+class TestConversationResult:
+    """Tests for ConversationResult model."""
+
+    def test_with_token_count(self) -> None:
+        """Test ConversationResult includes token count."""
+        result = ConversationResult(
+            turns=[
+                ConversationTurn(
+                    role="user",
+                    content="Hello",
+                    tool_calls=[],
+                    timestamp=1000.0,
+                ),
+                ConversationTurn(
+                    role="assistant",
+                    content="Hi there!",
+                    tool_calls=[],
+                    timestamp=1001.0,
+                ),
+            ],
+            final_answer="Hi there!",
+            total_tool_calls=[],
+            total_tokens=250,
+            duration_seconds=1.5,
+            termination_reason=TerminationReason.USER_SATISFIED,
+        )
+
+        assert result.total_tokens == 250
+        assert len(result.turns) == 2
+        assert result.termination_reason == TerminationReason.USER_SATISFIED
+
+    def test_default_token_count(self) -> None:
+        """Test ConversationResult default token count is 0."""
+        result = ConversationResult(
+            turns=[],
+            final_answer="",
+            total_tool_calls=[],
+            duration_seconds=0.5,
+            termination_reason=TerminationReason.MAX_TURNS,
+        )
+
+        assert result.total_tokens == 0
+
+
+class TestAgentResponse:
+    """Tests for AgentResponse model."""
+
+    def test_with_tool_calls(self) -> None:
+        """Test AgentResponse with tool calls."""
+        tool_call = ToolCall(
+            tool_name="search",
+            parameters={"query": "test"},
+            result=["result1"],
+            latency_ms=100.0,
+        )
+
+        response = AgentResponse(
+            message="Here's what I found",
+            tool_calls=[tool_call],
+            is_complete=True,
+            metadata={"model": "test"},
+        )
+
+        assert response.message == "Here's what I found"
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].tool_name == "search"
+        assert response.is_complete is True
+
+    def test_defaults(self) -> None:
+        """Test AgentResponse defaults."""
+        response = AgentResponse(message="Hello")
+
+        assert response.tool_calls == []
+        assert response.is_complete is False
+        assert response.metadata == {}

--- a/tests/unit/test_judge_prompts.py
+++ b/tests/unit/test_judge_prompts.py
@@ -1,0 +1,296 @@
+"""Tests for judge prompt formatting."""
+
+from mcprobe.judge.prompts import (
+    build_judge_prompt,
+    format_criteria_list,
+    format_tool_call_criteria,
+    format_tool_calls,
+)
+from mcprobe.models.conversation import (
+    ConversationResult,
+    ConversationTurn,
+    TerminationReason,
+    ToolCall,
+)
+from mcprobe.models.scenario import (
+    ClarificationBehavior,
+    EfficiencyConfig,
+    EvaluationConfig,
+    SyntheticUserConfig,
+    TestScenario,
+    ToolCallCriterion,
+    ToolUsageConfig,
+)
+
+
+class TestFormatToolCallCriteria:
+    """Tests for format_tool_call_criteria function."""
+
+    def test_empty_criteria(self) -> None:
+        """Test formatting empty criteria list."""
+        result = format_tool_call_criteria([])
+        assert result == "None specified"
+
+    def test_single_criterion(self) -> None:
+        """Test formatting single tool criterion."""
+        criteria = [
+            ToolCallCriterion(
+                tool="get_weather",
+                assertions=["location includes Phoenix"],
+            )
+        ]
+
+        result = format_tool_call_criteria(criteria)
+
+        assert "Tool: get_weather" in result
+        assert "location includes Phoenix" in result
+
+    def test_multiple_criteria(self) -> None:
+        """Test formatting multiple tool criteria with multiple assertions."""
+        criteria = [
+            ToolCallCriterion(
+                tool="get_weather",
+                assertions=[
+                    "location includes Phoenix",
+                    "forecast_days >= 3",
+                ],
+            ),
+            ToolCallCriterion(
+                tool="search",
+                assertions=["query is not empty"],
+            ),
+        ]
+
+        result = format_tool_call_criteria(criteria)
+
+        assert "Tool: get_weather" in result
+        assert "location includes Phoenix" in result
+        assert "forecast_days >= 3" in result
+        assert "Tool: search" in result
+        assert "query is not empty" in result
+
+
+class TestFormatCriteriaList:
+    """Tests for format_criteria_list function."""
+
+    def test_empty_list(self) -> None:
+        """Test formatting empty criteria list."""
+        result = format_criteria_list([])
+        assert result == "None specified"
+
+    def test_single_criterion(self) -> None:
+        """Test formatting single criterion."""
+        result = format_criteria_list(["Agent responds politely"])
+        assert result == "- Agent responds politely"
+
+    def test_multiple_criteria(self) -> None:
+        """Test formatting multiple criteria."""
+        criteria = [
+            "Agent responds politely",
+            "Agent provides accurate information",
+        ]
+        result = format_criteria_list(criteria)
+
+        assert "- Agent responds politely" in result
+        assert "- Agent provides accurate information" in result
+
+
+class TestFormatToolCalls:
+    """Tests for format_tool_calls function."""
+
+    def test_no_tool_calls(self) -> None:
+        """Test formatting when no tool calls made."""
+        result = ConversationResult(
+            turns=[],
+            final_answer="",
+            total_tool_calls=[],
+            total_tokens=0,
+            duration_seconds=1.0,
+            termination_reason=TerminationReason.USER_SATISFIED,
+        )
+
+        formatted = format_tool_calls(result)
+        assert formatted == "No tool calls were made."
+
+    def test_with_tool_calls(self) -> None:
+        """Test formatting tool calls."""
+        tool_calls = [
+            ToolCall(
+                tool_name="get_weather",
+                parameters={"location": "Phoenix"},
+                result={"temp": 95},
+                latency_ms=150.5,
+            ),
+            ToolCall(
+                tool_name="search",
+                parameters={"query": "test"},
+                result=["item1", "item2"],
+                latency_ms=200.0,
+            ),
+        ]
+
+        result = ConversationResult(
+            turns=[],
+            final_answer="",
+            total_tool_calls=tool_calls,
+            total_tokens=100,
+            duration_seconds=1.0,
+            termination_reason=TerminationReason.USER_SATISFIED,
+        )
+
+        formatted = format_tool_calls(result)
+
+        assert "1. get_weather" in formatted
+        assert "2. search" in formatted
+        assert "Phoenix" in formatted
+        assert "150.5ms" in formatted
+
+    def test_tool_call_with_error(self) -> None:
+        """Test formatting tool call with error."""
+        tool_calls = [
+            ToolCall(
+                tool_name="get_weather",
+                parameters={"location": "invalid"},
+                result=None,
+                latency_ms=50.0,
+                error="Location not found",
+            ),
+        ]
+
+        result = ConversationResult(
+            turns=[],
+            final_answer="",
+            total_tool_calls=tool_calls,
+            total_tokens=0,
+            duration_seconds=1.0,
+            termination_reason=TerminationReason.ERROR,
+        )
+
+        formatted = format_tool_calls(result)
+
+        assert "Error: Location not found" in formatted
+
+
+class TestBuildJudgePrompt:
+    """Tests for build_judge_prompt function."""
+
+    def test_includes_tool_call_criteria(self) -> None:
+        """Test that judge prompt includes tool call criteria."""
+        scenario = TestScenario(
+            name="Weather Test",
+            description="Test weather queries",
+            synthetic_user=SyntheticUserConfig(
+                persona="A user planning a trip",
+                initial_query="What's the weather in Phoenix?",
+                clarification_behavior=ClarificationBehavior(),
+                max_turns=5,
+            ),
+            evaluation=EvaluationConfig(
+                correctness_criteria=["Provides weather info"],
+                failure_criteria=[],
+                tool_usage=ToolUsageConfig(
+                    required_tools=["get_weather"],
+                    tool_call_criteria=[
+                        ToolCallCriterion(
+                            tool="get_weather",
+                            assertions=[
+                                "location includes Phoenix",
+                                "forecast_days >= 3",
+                            ],
+                        ),
+                    ],
+                ),
+                efficiency=EfficiencyConfig(max_conversation_turns=5),
+            ),
+        )
+
+        conversation_result = ConversationResult(
+            turns=[
+                ConversationTurn(
+                    role="user",
+                    content="What's the weather in Phoenix?",
+                    tool_calls=[],
+                    timestamp=1000.0,
+                ),
+            ],
+            final_answer="The weather is sunny",
+            total_tool_calls=[],
+            total_tokens=100,
+            duration_seconds=2.0,
+            termination_reason=TerminationReason.USER_SATISFIED,
+        )
+
+        prompt = build_judge_prompt(scenario, conversation_result)
+
+        # Verify tool call criteria section is included
+        assert "Tool Call Criteria" in prompt
+        assert "get_weather" in prompt
+        assert "location includes Phoenix" in prompt
+        assert "forecast_days >= 3" in prompt
+
+    def test_includes_quality_analysis_section(self) -> None:
+        """Test that judge prompt includes quality analysis section."""
+        scenario = TestScenario(
+            name="Test",
+            description="Test scenario",
+            synthetic_user=SyntheticUserConfig(
+                persona="User",
+                initial_query="Hello",
+                clarification_behavior=ClarificationBehavior(),
+                max_turns=5,
+            ),
+            evaluation=EvaluationConfig(
+                correctness_criteria=["Responds"],
+                efficiency=EfficiencyConfig(),
+            ),
+        )
+
+        conversation_result = ConversationResult(
+            turns=[],
+            final_answer="Hi",
+            total_tool_calls=[],
+            total_tokens=50,
+            duration_seconds=1.0,
+            termination_reason=TerminationReason.USER_SATISFIED,
+        )
+
+        prompt = build_judge_prompt(scenario, conversation_result)
+
+        # Verify quality analysis section
+        assert "Conversation Quality Analysis" in prompt
+        assert "clarifying questions" in prompt
+        assert "backtrack" in prompt
+
+    def test_includes_structured_suggestions_format(self) -> None:
+        """Test that judge prompt requests structured suggestions."""
+        scenario = TestScenario(
+            name="Test",
+            description="Test scenario",
+            synthetic_user=SyntheticUserConfig(
+                persona="User",
+                initial_query="Hello",
+                clarification_behavior=ClarificationBehavior(),
+                max_turns=5,
+            ),
+            evaluation=EvaluationConfig(
+                correctness_criteria=["Responds"],
+                efficiency=EfficiencyConfig(),
+            ),
+        )
+
+        conversation_result = ConversationResult(
+            turns=[],
+            final_answer="Hi",
+            total_tool_calls=[],
+            total_tokens=50,
+            duration_seconds=1.0,
+            termination_reason=TerminationReason.USER_SATISFIED,
+        )
+
+        prompt = build_judge_prompt(scenario, conversation_result)
+
+        # Verify structured suggestions format is requested
+        assert "structured_suggestions" in prompt
+        assert "category" in prompt
+        assert "severity" in prompt
+        assert "description|parameter|return_value|schema" in prompt

--- a/tests/unit/test_judgment_models.py
+++ b/tests/unit/test_judgment_models.py
@@ -1,0 +1,209 @@
+"""Tests for judgment data models."""
+
+import pytest
+from pydantic import ValidationError
+
+from mcprobe.models.judgment import (
+    JudgmentResult,
+    MCPSuggestion,
+    QualityMetrics,
+    SuggestionCategory,
+    SuggestionSeverity,
+)
+
+
+class TestQualityMetrics:
+    """Tests for QualityMetrics model."""
+
+    def test_default_values(self) -> None:
+        """Test QualityMetrics has sensible defaults."""
+        metrics = QualityMetrics()
+
+        assert metrics.clarification_count == 0
+        assert metrics.backtrack_count == 0
+        assert metrics.turns_to_first_answer == 0
+        assert metrics.final_answer_completeness == 0.0
+
+    def test_custom_values(self) -> None:
+        """Test QualityMetrics with custom values."""
+        metrics = QualityMetrics(
+            clarification_count=3,
+            backtrack_count=1,
+            turns_to_first_answer=2,
+            final_answer_completeness=0.85,
+        )
+
+        assert metrics.clarification_count == 3
+        assert metrics.backtrack_count == 1
+        assert metrics.turns_to_first_answer == 2
+        assert metrics.final_answer_completeness == 0.85
+
+    def test_completeness_validation(self) -> None:
+        """Test final_answer_completeness is bounded 0-1."""
+        # Valid boundary values
+        QualityMetrics(final_answer_completeness=0.0)
+        QualityMetrics(final_answer_completeness=1.0)
+
+        # Invalid values
+        with pytest.raises(ValidationError):
+            QualityMetrics(final_answer_completeness=-0.1)
+
+        with pytest.raises(ValidationError):
+            QualityMetrics(final_answer_completeness=1.1)
+
+
+class TestMCPSuggestion:
+    """Tests for MCPSuggestion model."""
+
+    def test_minimal_suggestion(self) -> None:
+        """Test MCPSuggestion with minimal required fields."""
+        suggestion = MCPSuggestion(
+            category=SuggestionCategory.DESCRIPTION,
+            issue="Tool description unclear",
+            suggestion="Add more detail about expected input format",
+        )
+
+        assert suggestion.category == SuggestionCategory.DESCRIPTION
+        assert suggestion.tool_name is None
+        assert suggestion.issue == "Tool description unclear"
+        assert suggestion.suggestion == "Add more detail about expected input format"
+        assert suggestion.severity == SuggestionSeverity.MEDIUM  # default
+
+    def test_full_suggestion(self) -> None:
+        """Test MCPSuggestion with all fields."""
+        suggestion = MCPSuggestion(
+            category=SuggestionCategory.PARAMETER,
+            tool_name="get_weather",
+            issue="Location parameter format not documented",
+            suggestion="Specify that location should be city name or coordinates",
+            severity=SuggestionSeverity.HIGH,
+        )
+
+        assert suggestion.category == SuggestionCategory.PARAMETER
+        assert suggestion.tool_name == "get_weather"
+        assert suggestion.severity == SuggestionSeverity.HIGH
+
+    def test_all_categories(self) -> None:
+        """Test all suggestion categories are valid."""
+        for category in SuggestionCategory:
+            suggestion = MCPSuggestion(
+                category=category,
+                issue="test issue",
+                suggestion="test suggestion",
+            )
+            assert suggestion.category == category
+
+    def test_all_severities(self) -> None:
+        """Test all severity levels are valid."""
+        for severity in SuggestionSeverity:
+            suggestion = MCPSuggestion(
+                category=SuggestionCategory.DESCRIPTION,
+                issue="test issue",
+                suggestion="test suggestion",
+                severity=severity,
+            )
+            assert suggestion.severity == severity
+
+
+class TestJudgmentResult:
+    """Tests for JudgmentResult model."""
+
+    def test_minimal_result(self) -> None:
+        """Test JudgmentResult with minimal required fields."""
+        result = JudgmentResult(
+            passed=True,
+            score=0.9,
+            correctness_results={"criterion1": True},
+            failure_results={"bad_thing": False},
+            tool_usage_results={},
+            efficiency_results={},
+            reasoning="Test passed successfully",
+        )
+
+        assert result.passed is True
+        assert result.score == 0.9
+        assert result.suggestions == []  # default
+        assert result.quality_metrics.clarification_count == 0  # default
+        assert result.structured_suggestions == []  # default
+
+    def test_full_result(self) -> None:
+        """Test JudgmentResult with all fields including Phase 3 additions."""
+        quality_metrics = QualityMetrics(
+            clarification_count=2,
+            backtrack_count=0,
+            turns_to_first_answer=3,
+            final_answer_completeness=0.95,
+        )
+
+        structured_suggestions = [
+            MCPSuggestion(
+                category=SuggestionCategory.PARAMETER,
+                tool_name="search",
+                issue="Limit parameter unclear",
+                suggestion="Document max value",
+                severity=SuggestionSeverity.LOW,
+            )
+        ]
+
+        result = JudgmentResult(
+            passed=True,
+            score=0.85,
+            correctness_results={"c1": True, "c2": True},
+            failure_results={"f1": False},
+            tool_usage_results={"required_tools_used": ["search"]},
+            efficiency_results={"total_tokens": 500, "within_limits": True},
+            reasoning="Good performance",
+            suggestions=["Consider caching"],
+            quality_metrics=quality_metrics,
+            structured_suggestions=structured_suggestions,
+        )
+
+        assert result.quality_metrics.clarification_count == 2
+        assert result.quality_metrics.final_answer_completeness == 0.95
+        assert len(result.structured_suggestions) == 1
+        assert result.structured_suggestions[0].tool_name == "search"
+
+    def test_score_validation(self) -> None:
+        """Test score is bounded 0-1."""
+        # Valid
+        JudgmentResult(
+            passed=True,
+            score=0.0,
+            correctness_results={},
+            failure_results={},
+            tool_usage_results={},
+            efficiency_results={},
+            reasoning="",
+        )
+        JudgmentResult(
+            passed=True,
+            score=1.0,
+            correctness_results={},
+            failure_results={},
+            tool_usage_results={},
+            efficiency_results={},
+            reasoning="",
+        )
+
+        # Invalid
+        with pytest.raises(ValidationError):
+            JudgmentResult(
+                passed=True,
+                score=-0.1,
+                correctness_results={},
+                failure_results={},
+                tool_usage_results={},
+                efficiency_results={},
+                reasoning="",
+            )
+
+        with pytest.raises(ValidationError):
+            JudgmentResult(
+                passed=True,
+                score=1.1,
+                correctness_results={},
+                failure_results={},
+                tool_usage_results={},
+                efficiency_results={},
+                reasoning="",
+            )

--- a/tests/unit/test_synthetic_user.py
+++ b/tests/unit/test_synthetic_user.py
@@ -1,0 +1,129 @@
+"""Tests for synthetic user token tracking."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcprobe.models.scenario import (
+    ClarificationBehavior,
+    SyntheticUserConfig,
+)
+from mcprobe.providers.base import LLMProvider, LLMResponse
+from mcprobe.synthetic_user.user import SyntheticUserLLM
+
+
+@pytest.fixture
+def mock_provider() -> LLMProvider:
+    """Create a mock LLM provider."""
+    provider = AsyncMock(spec=LLMProvider)
+    return provider
+
+
+@pytest.fixture
+def user_config() -> SyntheticUserConfig:
+    """Create a synthetic user config."""
+    return SyntheticUserConfig(
+        persona="A helpful test user",
+        initial_query="Hello, can you help me?",
+        clarification_behavior=ClarificationBehavior(),
+        max_turns=5,
+    )
+
+
+class TestSyntheticUserTokenTracking:
+    """Tests for token tracking in SyntheticUserLLM."""
+
+    @pytest.mark.asyncio
+    async def test_respond_returns_tokens_used(
+        self,
+        mock_provider: LLMProvider,
+        user_config: SyntheticUserConfig,
+    ) -> None:
+        """Test that respond returns token count from LLM response."""
+        # Mock LLM response with token usage
+        mock_response = LLMResponse(
+            content="Sure, I can help with that!",
+            tool_calls=[],
+            finish_reason="stop",
+            usage={"prompt_tokens": 100, "completion_tokens": 50},
+        )
+        mock_provider.generate = AsyncMock(return_value=mock_response)
+
+        user = SyntheticUserLLM(mock_provider, user_config)
+        response = await user.respond("How can I assist you today?")
+
+        # Verify tokens are tracked
+        assert response.tokens_used == 150  # 100 + 50
+
+    @pytest.mark.asyncio
+    async def test_respond_with_satisfaction_returns_tokens(
+        self,
+        mock_provider: LLMProvider,
+        user_config: SyntheticUserConfig,
+    ) -> None:
+        """Test that satisfied response includes token count."""
+        # Mock responses for satisfaction check and final response
+        mock_satisfaction_result = AsyncMock()
+        mock_satisfaction_result.is_satisfied = True
+        mock_provider.generate_structured = AsyncMock(return_value=mock_satisfaction_result)
+
+        mock_response = LLMResponse(
+            content="Thanks, that was helpful!",
+            tool_calls=[],
+            finish_reason="stop",
+            usage={"prompt_tokens": 80, "completion_tokens": 30},
+        )
+        mock_provider.generate = AsyncMock(return_value=mock_response)
+
+        user = SyntheticUserLLM(mock_provider, user_config)
+        response = await user.respond("Here's your answer", is_final_answer=True)
+
+        assert response.is_satisfied is True
+        assert response.tokens_used == 110  # 80 + 30
+
+    @pytest.mark.asyncio
+    async def test_tokens_reset_on_reset(
+        self,
+        mock_provider: LLMProvider,
+        user_config: SyntheticUserConfig,
+    ) -> None:
+        """Test that token tracking resets when user is reset."""
+        mock_response = LLMResponse(
+            content="Response",
+            tool_calls=[],
+            finish_reason="stop",
+            usage={"prompt_tokens": 50, "completion_tokens": 25},
+        )
+        mock_provider.generate = AsyncMock(return_value=mock_response)
+
+        user = SyntheticUserLLM(mock_provider, user_config)
+
+        # First response
+        response1 = await user.respond("Message 1")
+        assert response1.tokens_used == 75
+
+        # Reset user
+        user.reset()
+
+        # Verify internal state is reset
+        assert user._last_tokens_used == 0
+
+    @pytest.mark.asyncio
+    async def test_tokens_default_to_zero_on_missing_usage(
+        self,
+        mock_provider: LLMProvider,
+        user_config: SyntheticUserConfig,
+    ) -> None:
+        """Test that tokens default to 0 if usage info is missing keys."""
+        mock_response = LLMResponse(
+            content="Response",
+            tool_calls=[],
+            finish_reason="stop",
+            usage={},  # Empty usage dict
+        )
+        mock_provider.generate = AsyncMock(return_value=mock_response)
+
+        user = SyntheticUserLLM(mock_provider, user_config)
+        response = await user.respond("Hello")
+
+        assert response.tokens_used == 0


### PR DESCRIPTION
## Summary
Phase 3 implementation adds detailed tool usage scoring, efficiency metrics, conversation quality analysis, and structured MCP server improvement suggestions.

- Add `QualityMetrics` model tracking clarifications, backtracks, turns to answer, and answer completeness
- Add `MCPSuggestion` model with `SuggestionCategory` and `SuggestionSeverity` enums for structured feedback
- Track token usage from LLM responses through conversation flow (`UserResponse.tokens_used`, `ConversationResult.total_tokens`)
- Include `tool_call_criteria` assertions in judge evaluation prompt
- Add quality analysis and structured suggestions sections to judge prompt
- Display new metrics in CLI verbose output (quality metrics, efficiency, MCP suggestions)
- Add comprehensive unit and integration tests (39 tests)

## Files Changed
| File | Changes |
|------|---------|
| `models/judgment.py` | `QualityMetrics`, `MCPSuggestion`, enums, updated `JudgmentResult` |
| `models/conversation.py` | `tokens_used` field in `UserResponse` |
| `judge/prompts.py` | Tool call criteria formatting, quality analysis section |
| `judge/judge.py` | Parse new evaluation fields, build structured suggestions |
| `synthetic_user/user.py` | Track and return token counts |
| `orchestrator/orchestrator.py` | Aggregate token counts |
| `cli/main.py` | Display quality metrics and structured suggestions |
| `pyproject.toml` | Test linting configuration |

## Test Plan
- [x] 39 unit and integration tests pass
- [x] All source files pass mypy strict mode
- [x] All files pass ruff check and format