### PR TITLE
Add ADK agent support to pytest plugin and fix synthetic user issues

### DIFF
--- a/src/mcprobe/synthetic_user/prompts.py
+++ b/src/mcprobe/synthetic_user/prompts.py
@@ -6,8 +6,13 @@ These templates define how the synthetic user should behave during conversations
 from mcprobe.models.scenario import SyntheticUserConfig
 
 SYNTHETIC_USER_SYSTEM_PROMPT = """\
-You are simulating a user interacting with an AI assistant.
-Your goal is to get help with a specific task while behaving like a realistic human user.
+You are role-playing as a USER who is asking an AI assistant for help.
+
+CRITICAL: You are the USER, not the assistant. You must:
+- ONLY ask questions or respond to questions
+- NEVER provide data, answers, or technical information
+- NEVER say things like "Would you like to know more?" - that's what assistants say
+- NEVER summarize or explain data - you are asking for help, not giving it
 
 ## Your Persona
 {persona}
@@ -15,7 +20,7 @@ Your goal is to get help with a specific task while behaving like a realistic hu
 ## Your Initial Question
 {initial_query}
 
-## What You Know (provide if asked)
+## What You Know (provide ONLY if directly asked by the assistant)
 {known_facts}
 
 ## What You Don't Know (say "I'm not sure" or "I don't know")
@@ -28,16 +33,15 @@ Your goal is to get help with a specific task while behaving like a realistic hu
 
 ## Instructions
 1. When the assistant asks for clarification:
-   - If you know the answer (from "What You Know"), provide it naturally
+   - If you know the answer (from "What You Know"), provide it briefly
    - If you don't know, say so realistically
    - If the assistant keeps asking questions, you may express mild impatience
 2. When the assistant provides an answer:
-   - If it seems to address your question, thank them and indicate you're satisfied
-   - If it's incomplete or wrong, ask follow-up questions
+   - If it addresses your question, thank them briefly
+   - If it's incomplete, ask a follow-up question
    - If you're unsure, ask for clarification
-3. Never break character or reveal you're a synthetic user
-4. Respond conversationally, not in bullet points
-5. Keep responses brief unless asked for details
+3. Keep responses SHORT (1-2 sentences max)
+4. You are asking for help - do NOT provide information unprompted
 
 Signal completion by saying "Thanks, that's helpful!" or "Great, that answers my question."
 """

--- a/src/mcprobe/synthetic_user/user.py
+++ b/src/mcprobe/synthetic_user/user.py
@@ -148,10 +148,16 @@ class SyntheticUserLLM:
             "completion_tokens", 0
         )
 
-        # Add our response to history
-        self._conversation_history.append(Message(role="user", content=response.content))
+        content = response.content.strip()
 
-        return response.content
+        # Handle empty responses - indicate satisfaction instead of sending empty message
+        if not content:
+            content = "Thanks, that answers my question."
+
+        # Add our response to history
+        self._conversation_history.append(Message(role="user", content=content))
+
+        return content
 
     async def _check_satisfaction(self, assistant_response: str) -> bool:
         """Check if the user would be satisfied with the response.


### PR DESCRIPTION
## Summary
- Add ADK agent support to pytest plugin
- Fix synthetic user role confusion issues
- Fix various deprecation warnings

Closes #8

## Changes

### Pytest Plugin Improvements
- Add `--mcprobe-agent-factory` option for specifying ADK agent factory module
- Add `--mcprobe-agent-type` option to choose between `simple` and `adk` agents
- Refactor `_run_scenario` to use `ScenarioRunConfig` dataclass
- Fix `asyncio.get_event_loop()` deprecation warning
- Fix redundant marker bug and suppress unknown mark warnings

### Synthetic User Fixes
- Strengthen system prompt to prevent role confusion
- Handle empty LLM responses with default satisfaction message

## Test plan
- [x] All existing tests pass (140 passed)
- [x] Tested with example MCP server project using ADK agent