### PR TITLE
Add configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ mcprobe run test-scenario.yaml
 mcprobe run test-scenario.yaml --provider openai --model gpt-4
 ```
 
+**Using a Configuration File:**
+
+Create `mcprobe.yaml`:
+```yaml
+llm:
+  provider: ollama
+  model: llama3.2
+  base_url: http://localhost:11434
+```
+
+Then run:
+```bash
+mcprobe run test-scenario.yaml
+```
+
 ### View Results
 
 ```
@@ -106,6 +121,10 @@ mcprobe run scenario.yaml -v        # Run with verbose output
 mcprobe run scenario.yaml --provider ollama --model llama3.2
 mcprobe run scenario.yaml --provider openai --model gpt-4
 
+# Use configuration file
+mcprobe run scenario.yaml --config mcprobe.yaml
+mcprobe run scenario.yaml -c mcprobe.yaml
+
 # Generate scenarios from MCP server
 mcprobe generate-scenarios --server "npx @example/weather-mcp" -o ./scenarios
 
@@ -130,6 +149,12 @@ MCProbe includes a pytest plugin for seamless test integration:
 ```bash
 # Run scenarios as pytest tests
 pytest scenarios/ -v
+
+# Use config file
+pytest scenarios/ --mcprobe-config mcprobe.yaml
+
+# Override config with CLI options
+pytest scenarios/ --mcprobe-provider openai --mcprobe-model gpt-4
 
 # Save results for analysis
 pytest scenarios/ --mcprobe-save-results

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -252,7 +252,46 @@ For advanced setups with custom LLM providers, see the [Integration Guide](../in
 
 ## Configuration
 
-MCProbe can be configured via command-line options or environment variables.
+MCProbe can be configured via configuration files, command-line options, or environment variables.
+
+### Configuration Files
+
+Create a `mcprobe.yaml` file for centralized configuration:
+
+```yaml
+# mcprobe.yaml
+llm:
+  provider: ollama
+  model: llama3.2
+  base_url: http://localhost:11434
+  temperature: 0.0
+
+orchestrator:
+  max_turns: 10
+  turn_timeout_seconds: 30.0
+
+results:
+  save: true
+  dir: test-results
+```
+
+MCProbe automatically discovers config files in the current directory:
+
+```bash
+# Uses mcprobe.yaml if present
+mcprobe run scenario.yaml
+```
+
+Or specify an explicit config file:
+
+```bash
+mcprobe run scenario.yaml --config mcprobe.yaml
+```
+
+See [Configuration Reference](../configuration/reference.md) for complete documentation including:
+- Environment variable interpolation (`${VAR}` syntax)
+- Component-specific configs (separate settings for judge vs synthetic user)
+- Multiple provider configurations
 
 ### Environment Variables
 
@@ -260,11 +299,19 @@ MCProbe can be configured via command-line options or environment variables.
 # Ollama base URL (default: http://localhost:11434)
 export OLLAMA_BASE_URL="http://localhost:11434"
 
-# Default model (default: llama3.2)
-export MCPROBE_DEFAULT_MODEL="llama3.1:8b"
+# OpenAI API key (required for OpenAI provider)
+export OPENAI_API_KEY="sk-your-key-here"
+```
 
-# Results storage directory (default: test-results)
-export MCPROBE_RESULTS_DIR="./my-test-results"
+Environment variables can be used in config files:
+
+```yaml
+# mcprobe.yaml
+llm:
+  provider: openai
+  model: gpt-4
+  api_key: ${OPENAI_API_KEY}
+  base_url: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
 ```
 
 ### Command-Line Options
@@ -273,10 +320,12 @@ Override defaults when running tests:
 
 ```bash
 mcprobe run scenario.yaml \
-  --model llama3.1:8b \
-  --base-url http://remote-ollama:11434 \
+  --provider openai \
+  --model gpt-4 \
   --verbose
 ```
+
+CLI options override config file settings.
 
 ## Troubleshooting
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -126,6 +126,25 @@ mcprobe run greeting.yaml
 mcprobe run greeting.yaml --provider openai --model gpt-4
 ```
 
+**Using a Configuration File** (recommended for multiple runs):
+
+Create `mcprobe.yaml`:
+```yaml
+llm:
+  provider: ollama
+  model: llama3.2
+  base_url: http://localhost:11434
+
+results:
+  save: true
+  dir: test-results
+```
+
+Then run:
+```bash
+mcprobe run greeting.yaml
+```
+
 You'll see output like:
 
 ```
@@ -265,7 +284,16 @@ ollama pull llama3.2
 export OPENAI_API_KEY="sk-your-key-here"
 ```
 
-Or provide it in your configuration (see [Configuration Reference](../configuration/reference.md)).
+Or provide it in a configuration file:
+```yaml
+# mcprobe.yaml
+llm:
+  provider: openai
+  model: gpt-4
+  api_key: ${OPENAI_API_KEY}
+```
+
+See [Configuration Reference](../configuration/reference.md) for more details.
 
 ### Test Fails Unexpectedly
 
@@ -279,7 +307,33 @@ Or provide it in your configuration (see [Configuration Reference](../configurat
 
 Congratulations! You've run your first MCProbe test. Here's what to learn next:
 
-### 1. Create a More Complex Scenario
+### 1. Set Up a Configuration File
+
+For repeated testing, create a configuration file:
+
+```yaml
+# mcprobe.yaml
+llm:
+  provider: ollama
+  model: llama3.2
+  base_url: http://localhost:11434
+  temperature: 0.0
+
+orchestrator:
+  max_turns: 10
+  turn_timeout_seconds: 30.0
+
+results:
+  save: true
+  dir: test-results
+```
+
+See [Configuration Reference](../configuration/reference.md) for all options including:
+- Component-specific configs (separate settings for judge vs synthetic user)
+- Environment variable interpolation
+- Multiple provider configurations
+
+### 2. Create a More Complex Scenario
 
 Try the [First Scenario Tutorial](first-scenario.md) to learn:
 - How to define realistic user personas
@@ -287,7 +341,7 @@ Try the [First Scenario Tutorial](first-scenario.md) to learn:
 - Testing tool usage with MCP servers
 - Writing effective evaluation criteria
 
-### 2. Test a Real MCP Agent
+### 3. Test a Real MCP Agent
 
 Learn how to test agents that use MCP tools:
 - Connect to MCP servers
@@ -295,7 +349,7 @@ Learn how to test agents that use MCP tools:
 - Validate tool call parameters
 - Test multi-tool scenarios
 
-### 3. Generate Test Reports
+### 4. Generate Test Reports
 
 Create shareable HTML reports:
 
@@ -307,7 +361,7 @@ mcprobe run greeting.yaml
 mcprobe report --format html --output report.html
 ```
 
-### 4. Track Trends Over Time
+### 5. Track Trends Over Time
 
 Run the same scenario multiple times and analyze trends:
 
@@ -319,7 +373,7 @@ for i in {1..10}; do mcprobe run greeting.yaml; done
 mcprobe trends --scenario "Simple Greeting Test"
 ```
 
-### 5. Detect Flaky Tests
+### 6. Detect Flaky Tests
 
 Identify scenarios with inconsistent results:
 

--- a/src/mcprobe/config/__init__.py
+++ b/src/mcprobe/config/__init__.py
@@ -1,0 +1,19 @@
+"""Configuration file support for mcprobe."""
+
+from mcprobe.config.loader import (
+    AgentConfig,
+    CLIOverrides,
+    ConfigLoader,
+    FileConfig,
+    ResultsConfig,
+    load_config,
+)
+
+__all__ = [
+    "AgentConfig",
+    "CLIOverrides",
+    "ConfigLoader",
+    "FileConfig",
+    "ResultsConfig",
+    "load_config",
+]

--- a/src/mcprobe/config/loader.py
+++ b/src/mcprobe/config/loader.py
@@ -1,0 +1,401 @@
+"""Configuration file loader.
+
+Handles discovery, parsing, and merging of YAML configuration files.
+"""
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, SecretStr
+
+from mcprobe.exceptions import ConfigurationError
+from mcprobe.models.config import LLMConfig, OrchestratorConfig
+
+
+@dataclass
+class _ResolvedValues:
+    """Internal dataclass to hold resolved configuration values during merging."""
+
+    provider: str
+    model: str
+    temperature: float
+    max_tokens: int
+    base_url: str | None
+    api_key: str | None
+
+# Pattern matches ${VAR} or ${VAR:-default}
+ENV_VAR_PATTERN = re.compile(r"\$\{([^}:-]+)(?::-([^}]*))?\}")
+
+# Default config file names in priority order
+CONFIG_FILE_NAMES = ["mcprobe.yaml", ".mcprobe.yaml", "mcprobe.yml", ".mcprobe.yml"]
+
+
+class AgentConfig(BaseModel):
+    """Configuration for the agent under test."""
+
+    type: str = "simple"
+    factory: str | None = None
+
+
+class ResultsConfig(BaseModel):
+    """Configuration for test result storage."""
+
+    save: bool = True
+    dir: str = "test-results"
+
+
+class CLIOverrides(BaseModel):
+    """CLI argument overrides for configuration.
+
+    All fields are optional - only set values will override config file settings.
+    """
+
+    provider: str | None = None
+    model: str | None = None
+    base_url: str | None = None
+    api_key: str | None = None
+    temperature: float | None = None
+    max_tokens: int | None = None
+
+
+class FileConfig(BaseModel):
+    """Schema for mcprobe.yaml configuration file."""
+
+    agent: AgentConfig = Field(default_factory=AgentConfig)
+    llm: LLMConfig | None = None
+    judge: LLMConfig | None = None
+    synthetic_user: LLMConfig | None = None
+    orchestrator: OrchestratorConfig = Field(default_factory=OrchestratorConfig)
+    results: ResultsConfig = Field(default_factory=ResultsConfig)
+
+
+class ConfigLoader:
+    """Load and merge configuration from files and CLI arguments."""
+
+    @staticmethod
+    def discover_config_file(explicit_path: Path | None = None) -> Path | None:
+        """Find configuration file in priority order.
+
+        Args:
+            explicit_path: Explicitly provided config file path.
+
+        Returns:
+            Path to config file, or None if not found.
+
+        Raises:
+            ConfigurationError: If explicit path doesn't exist.
+        """
+        # 1. Use explicit path if provided
+        if explicit_path is not None:
+            if not explicit_path.exists():
+                msg = f"Configuration file not found: {explicit_path}"
+                raise ConfigurationError(msg)
+            return explicit_path
+
+        # 2. Search in current directory
+        cwd = Path.cwd()
+        for filename in CONFIG_FILE_NAMES:
+            config_path = cwd / filename
+            if config_path.exists():
+                return config_path
+
+        # 3. No config file found (silent, no warning)
+        return None
+
+    @staticmethod
+    def load_yaml(path: Path) -> dict[str, Any]:
+        """Load and parse YAML configuration file.
+
+        Args:
+            path: Path to YAML file.
+
+        Returns:
+            Parsed configuration dictionary.
+
+        Raises:
+            ConfigurationError: If file cannot be read or parsed.
+        """
+        try:
+            with path.open() as f:
+                content = yaml.safe_load(f)
+                return content if content is not None else {}
+        except yaml.YAMLError as e:
+            msg = f"Failed to parse configuration file {path}: {e}"
+            raise ConfigurationError(msg) from e
+        except OSError as e:
+            msg = f"Failed to read configuration file {path}: {e}"
+            raise ConfigurationError(msg) from e
+
+    @staticmethod
+    def interpolate_env_vars(value: Any) -> Any:
+        """Recursively interpolate environment variables in configuration.
+
+        Supports two syntaxes:
+        - ${VAR} - Required variable, raises error if not set
+        - ${VAR:-default} - Optional variable with default value
+
+        Args:
+            value: Configuration value (string, dict, list, or other).
+
+        Returns:
+            Value with environment variables interpolated.
+
+        Raises:
+            ConfigurationError: If required environment variable is not set.
+        """
+        if isinstance(value, str):
+
+            def replace(match: re.Match[str]) -> str:
+                var_name = match.group(1)
+                default_value = match.group(2)  # None if no default specified
+                env_value = os.environ.get(var_name)
+                if env_value is not None:
+                    return env_value
+                if default_value is not None:
+                    return default_value
+                msg = f"Environment variable {var_name} is not set"
+                raise ConfigurationError(msg)
+
+            return ENV_VAR_PATTERN.sub(replace, value)
+        elif isinstance(value, dict):
+            return {k: ConfigLoader.interpolate_env_vars(v) for k, v in value.items()}
+        elif isinstance(value, list):
+            return [ConfigLoader.interpolate_env_vars(item) for item in value]
+        return value
+
+    @staticmethod
+    def load_config(explicit_path: Path | None = None) -> FileConfig | None:
+        """Discover, load, and parse configuration file.
+
+        Args:
+            explicit_path: Explicitly provided config file path.
+
+        Returns:
+            Parsed FileConfig, or None if no config file found.
+
+        Raises:
+            ConfigurationError: If config file exists but is invalid.
+        """
+        config_path = ConfigLoader.discover_config_file(explicit_path)
+        if config_path is None:
+            return None
+
+        raw_config = ConfigLoader.load_yaml(config_path)
+        interpolated = ConfigLoader.interpolate_env_vars(raw_config)
+
+        try:
+            return FileConfig.model_validate(interpolated)
+        except Exception as e:
+            msg = f"Invalid configuration in {config_path}: {e}"
+            raise ConfigurationError(msg) from e
+
+    @staticmethod
+    def _apply_llm_config(source: LLMConfig, values: _ResolvedValues) -> None:
+        """Apply values from an LLMConfig source (mutates values in place)."""
+        values.provider = source.provider
+        values.model = source.model
+        values.temperature = source.temperature
+        values.max_tokens = source.max_tokens
+        values.base_url = source.base_url or values.base_url
+        if source.api_key:
+            values.api_key = source.api_key.get_secret_value()
+
+    @staticmethod
+    def _apply_cli_overrides(cli: CLIOverrides, values: _ResolvedValues) -> None:
+        """Apply CLI overrides to configuration values (mutates values in place)."""
+        if cli.provider is not None:
+            values.provider = cli.provider
+        if cli.model is not None:
+            values.model = cli.model
+        if cli.temperature is not None:
+            values.temperature = cli.temperature
+        if cli.max_tokens is not None:
+            values.max_tokens = cli.max_tokens
+        if cli.base_url is not None:
+            values.base_url = cli.base_url
+        if cli.api_key is not None:
+            values.api_key = cli.api_key
+
+    @staticmethod
+    def resolve_llm_config(
+        file_config: FileConfig | None,
+        component: str,
+        cli_overrides: CLIOverrides | None = None,
+        default_provider: str = "ollama",
+        default_model: str = "llama3.2",
+    ) -> LLMConfig:
+        """Resolve LLM configuration for a specific component.
+
+        Priority order (highest to lowest):
+        1. CLI arguments (via cli_overrides)
+        2. Component-specific config (judge:, synthetic_user:)
+        3. Shared LLM config (llm:)
+        4. Defaults
+
+        Args:
+            file_config: Parsed configuration file, or None.
+            component: Component name ("judge", "synthetic_user", or "llm").
+            cli_overrides: CLI argument overrides, or None.
+            default_provider: Default provider if not specified.
+            default_model: Default model if not specified.
+
+        Returns:
+            Resolved LLMConfig for the component.
+        """
+        # Start with defaults
+        values = _ResolvedValues(
+            provider=default_provider,
+            model=default_model,
+            temperature=0.0,
+            max_tokens=4096,
+            base_url=None,
+            api_key=None,
+        )
+
+        # Apply shared llm config
+        if file_config and file_config.llm:
+            ConfigLoader._apply_llm_config(file_config.llm, values)
+
+        # Apply component-specific config
+        component_config: LLMConfig | None = None
+        if file_config:
+            component_config = getattr(file_config, component, None)
+        if component_config:
+            ConfigLoader._apply_llm_config(component_config, values)
+
+        # Apply CLI overrides (highest priority)
+        if cli_overrides:
+            ConfigLoader._apply_cli_overrides(cli_overrides, values)
+
+        return LLMConfig(
+            provider=values.provider,
+            model=values.model,
+            temperature=values.temperature,
+            max_tokens=values.max_tokens,
+            base_url=values.base_url,
+            api_key=SecretStr(values.api_key) if values.api_key else None,
+        )
+
+    @staticmethod
+    def resolve_orchestrator_config(
+        file_config: FileConfig | None,
+        *,
+        cli_max_turns: int | None = None,
+        cli_timeout: float | None = None,
+    ) -> OrchestratorConfig:
+        """Resolve orchestrator configuration.
+
+        Args:
+            file_config: Parsed configuration file, or None.
+            cli_max_turns: CLI max turns override.
+            cli_timeout: CLI timeout override.
+
+        Returns:
+            Resolved OrchestratorConfig.
+        """
+        # Start with defaults
+        max_turns = 10
+        timeout = 30.0
+        loop_detection = 3
+
+        # Apply file config
+        if file_config:
+            max_turns = file_config.orchestrator.max_turns
+            timeout = file_config.orchestrator.turn_timeout_seconds
+            loop_detection = file_config.orchestrator.loop_detection_threshold
+
+        # Apply CLI overrides
+        if cli_max_turns is not None:
+            max_turns = cli_max_turns
+        if cli_timeout is not None:
+            timeout = cli_timeout
+
+        return OrchestratorConfig(
+            max_turns=max_turns,
+            turn_timeout_seconds=timeout,
+            loop_detection_threshold=loop_detection,
+        )
+
+    @staticmethod
+    def resolve_results_config(
+        file_config: FileConfig | None,
+        *,
+        cli_save: bool | None = None,
+        cli_dir: str | None = None,
+    ) -> ResultsConfig:
+        """Resolve results storage configuration.
+
+        Args:
+            file_config: Parsed configuration file, or None.
+            cli_save: CLI save results override.
+            cli_dir: CLI results directory override.
+
+        Returns:
+            Resolved ResultsConfig.
+        """
+        # Start with defaults
+        save = True
+        results_dir = "test-results"
+
+        # Apply file config
+        if file_config:
+            save = file_config.results.save
+            results_dir = file_config.results.dir
+
+        # Apply CLI overrides
+        if cli_save is not None:
+            save = cli_save
+        if cli_dir is not None:
+            results_dir = cli_dir
+
+        return ResultsConfig(save=save, dir=results_dir)
+
+    @staticmethod
+    def resolve_agent_config(
+        file_config: FileConfig | None,
+        *,
+        cli_agent_type: str | None = None,
+        cli_agent_factory: str | None = None,
+    ) -> AgentConfig:
+        """Resolve agent under test configuration.
+
+        Args:
+            file_config: Parsed configuration file, or None.
+            cli_agent_type: CLI agent type override.
+            cli_agent_factory: CLI agent factory override.
+
+        Returns:
+            Resolved AgentConfig.
+        """
+        # Start with defaults
+        agent_type = "simple"
+        factory = None
+
+        # Apply file config
+        if file_config:
+            agent_type = file_config.agent.type
+            factory = file_config.agent.factory
+
+        # Apply CLI overrides
+        if cli_agent_type is not None:
+            agent_type = cli_agent_type
+        if cli_agent_factory is not None:
+            factory = cli_agent_factory
+
+        return AgentConfig(type=agent_type, factory=factory)
+
+
+def load_config(explicit_path: Path | None = None) -> FileConfig | None:
+    """Convenience function to load configuration.
+
+    Args:
+        explicit_path: Explicitly provided config file path.
+
+    Returns:
+        Parsed FileConfig, or None if no config file found.
+    """
+    return ConfigLoader.load_config(explicit_path)

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,0 +1,559 @@
+"""Tests for configuration file loader."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from mcprobe.config import AgentConfig, CLIOverrides, ConfigLoader, FileConfig, ResultsConfig
+from mcprobe.exceptions import ConfigurationError
+from mcprobe.models.config import LLMConfig, OrchestratorConfig
+
+
+class TestConfigFileDiscovery:
+    """Tests for config file discovery."""
+
+    def test_discover_explicit_path(self, tmp_path: Path) -> None:
+        """Uses provided explicit path."""
+        config_file = tmp_path / "custom-config.yaml"
+        config_file.write_text("llm:\n  provider: openai\n  model: gpt-4\n")
+
+        result = ConfigLoader.discover_config_file(config_file)
+        assert result == config_file
+
+    def test_discover_explicit_path_not_found_raises(self, tmp_path: Path) -> None:
+        """Raises ConfigurationError for missing explicit path."""
+        missing_file = tmp_path / "missing.yaml"
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            ConfigLoader.discover_config_file(missing_file)
+        assert "not found" in str(exc_info.value)
+
+    def test_discover_mcprobe_yaml(self, tmp_path: Path) -> None:
+        """Finds mcprobe.yaml in current directory."""
+        config_file = tmp_path / "mcprobe.yaml"
+        config_file.write_text("llm:\n  provider: ollama\n  model: llama3.2\n")
+
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            result = ConfigLoader.discover_config_file()
+        assert result == config_file
+
+    def test_discover_dot_mcprobe_yaml(self, tmp_path: Path) -> None:
+        """Finds .mcprobe.yaml in current directory."""
+        config_file = tmp_path / ".mcprobe.yaml"
+        config_file.write_text("llm:\n  provider: ollama\n  model: llama3.2\n")
+
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            result = ConfigLoader.discover_config_file()
+        assert result == config_file
+
+    def test_discover_priority_mcprobe_over_dot(self, tmp_path: Path) -> None:
+        """mcprobe.yaml takes priority over .mcprobe.yaml."""
+        (tmp_path / "mcprobe.yaml").write_text("llm:\n  model: gpt-4\n")
+        (tmp_path / ".mcprobe.yaml").write_text("llm:\n  model: llama3.2\n")
+
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            result = ConfigLoader.discover_config_file()
+        assert result == tmp_path / "mcprobe.yaml"
+
+    def test_discover_none_when_no_file(self, tmp_path: Path) -> None:
+        """Returns None when no config file found (silent)."""
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            result = ConfigLoader.discover_config_file()
+        assert result is None
+
+
+class TestYamlLoading:
+    """Tests for YAML file loading."""
+
+    def test_load_valid_yaml(self, tmp_path: Path) -> None:
+        """Parses valid YAML config file."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "llm:\n"
+            "  provider: openai\n"
+            "  model: gpt-4\n"
+            "orchestrator:\n"
+            "  max_turns: 5\n"
+        )
+
+        result = ConfigLoader.load_yaml(config_file)
+        assert result["llm"]["provider"] == "openai"
+        assert result["llm"]["model"] == "gpt-4"
+        assert result["orchestrator"]["max_turns"] == 5
+
+    def test_load_empty_yaml_returns_empty_dict(self, tmp_path: Path) -> None:
+        """Empty YAML file returns empty dict."""
+        config_file = tmp_path / "empty.yaml"
+        config_file.write_text("")
+
+        result = ConfigLoader.load_yaml(config_file)
+        assert result == {}
+
+    def test_load_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        """Invalid YAML raises ConfigurationError."""
+        config_file = tmp_path / "invalid.yaml"
+        config_file.write_text("invalid: yaml: content:")
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            ConfigLoader.load_yaml(config_file)
+        assert "Failed to parse" in str(exc_info.value)
+
+    def test_load_missing_file_raises(self, tmp_path: Path) -> None:
+        """Missing file raises ConfigurationError."""
+        missing_file = tmp_path / "missing.yaml"
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            ConfigLoader.load_yaml(missing_file)
+        assert "Failed to read" in str(exc_info.value)
+
+
+class TestEnvironmentInterpolation:
+    """Tests for environment variable interpolation."""
+
+    def test_interpolate_simple_var(self) -> None:
+        """${VAR} is replaced with environment value."""
+        with patch.dict(os.environ, {"MY_API_KEY": "secret123"}):
+            result = ConfigLoader.interpolate_env_vars("${MY_API_KEY}")
+        assert result == "secret123"
+
+    def test_interpolate_with_default_uses_default(self) -> None:
+        """${VAR:-default} uses default when var is not set."""
+        # Make sure the variable is not set
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("MISSING_VAR", None)
+            result = ConfigLoader.interpolate_env_vars("${MISSING_VAR:-fallback}")
+        assert result == "fallback"
+
+    def test_interpolate_with_default_uses_env_when_set(self) -> None:
+        """${VAR:-default} uses env var value when set."""
+        with patch.dict(os.environ, {"MY_VAR": "actual_value"}):
+            result = ConfigLoader.interpolate_env_vars("${MY_VAR:-default}")
+        assert result == "actual_value"
+
+    def test_interpolate_empty_default(self) -> None:
+        """${VAR:-} allows empty string as default."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("MISSING_VAR", None)
+            result = ConfigLoader.interpolate_env_vars("${MISSING_VAR:-}")
+        assert result == ""
+
+    def test_interpolate_nested_dict(self) -> None:
+        """Interpolates variables in nested structures."""
+        with patch.dict(os.environ, {"API_KEY": "key123", "BASE_URL": "http://api.example.com"}):
+            config = {
+                "llm": {
+                    "api_key": "${API_KEY}",
+                    "base_url": "${BASE_URL}",
+                }
+            }
+            result = ConfigLoader.interpolate_env_vars(config)
+        assert result["llm"]["api_key"] == "key123"
+        assert result["llm"]["base_url"] == "http://api.example.com"
+
+    def test_interpolate_list(self) -> None:
+        """Interpolates variables in lists."""
+        with patch.dict(os.environ, {"VAR1": "value1", "VAR2": "value2"}):
+            config = ["${VAR1}", "${VAR2}"]
+            result = ConfigLoader.interpolate_env_vars(config)
+        assert result == ["value1", "value2"]
+
+    def test_interpolate_missing_var_raises(self) -> None:
+        """Raises ConfigurationError for undefined variable without default."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("UNDEFINED_VAR", None)
+            with pytest.raises(ConfigurationError) as exc_info:
+                ConfigLoader.interpolate_env_vars("${UNDEFINED_VAR}")
+        assert "UNDEFINED_VAR" in str(exc_info.value)
+        assert "not set" in str(exc_info.value)
+
+    def test_interpolate_no_vars_unchanged(self) -> None:
+        """Strings without variables pass through unchanged."""
+        result = ConfigLoader.interpolate_env_vars("plain string without vars")
+        assert result == "plain string without vars"
+
+    def test_interpolate_non_string_types_unchanged(self) -> None:
+        """Non-string types pass through unchanged."""
+        assert ConfigLoader.interpolate_env_vars(42) == 42
+        assert ConfigLoader.interpolate_env_vars(3.14) == 3.14
+        assert ConfigLoader.interpolate_env_vars(True) is True
+        assert ConfigLoader.interpolate_env_vars(None) is None
+
+    def test_interpolate_mixed_content(self) -> None:
+        """Interpolates variables embedded in larger strings."""
+        with patch.dict(os.environ, {"HOST": "localhost", "PORT": "8080"}):
+            result = ConfigLoader.interpolate_env_vars("http://${HOST}:${PORT}/api")
+        assert result == "http://localhost:8080/api"
+
+
+class TestLoadConfig:
+    """Tests for full config loading."""
+
+    def test_load_config_returns_file_config(self, tmp_path: Path) -> None:
+        """Returns validated FileConfig object."""
+        config_file = tmp_path / "mcprobe.yaml"
+        config_file.write_text(
+            "llm:\n"
+            "  provider: openai\n"
+            "  model: gpt-4\n"
+            "  temperature: 0.5\n"
+        )
+
+        result = ConfigLoader.load_config(config_file)
+        assert isinstance(result, FileConfig)
+        assert result.llm is not None
+        assert result.llm.provider == "openai"
+        assert result.llm.model == "gpt-4"
+        assert result.llm.temperature == 0.5
+
+    def test_load_config_with_env_vars(self, tmp_path: Path) -> None:
+        """Environment variables are interpolated."""
+        config_file = tmp_path / "mcprobe.yaml"
+        config_file.write_text(
+            "llm:\n"
+            "  provider: openai\n"
+            "  model: gpt-4\n"
+            "  api_key: ${TEST_API_KEY}\n"
+        )
+
+        with patch.dict(os.environ, {"TEST_API_KEY": "secret_key"}):
+            result = ConfigLoader.load_config(config_file)
+
+        assert result is not None
+        assert result.llm is not None
+        assert result.llm.api_key is not None
+        assert result.llm.api_key.get_secret_value() == "secret_key"
+
+    def test_load_config_returns_none_when_not_found(self, tmp_path: Path) -> None:
+        """Returns None when no config file found."""
+        with patch.object(Path, "cwd", return_value=tmp_path):
+            result = ConfigLoader.load_config()
+        assert result is None
+
+    def test_load_config_invalid_schema_raises(self, tmp_path: Path) -> None:
+        """Raises ConfigurationError for invalid config schema."""
+        config_file = tmp_path / "invalid.yaml"
+        config_file.write_text(
+            "llm:\n"
+            "  provider: invalid_provider\n"
+            "  model: 123\n"  # Invalid: model should be string
+            "  temperature: 'not_a_number'\n"
+        )
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            ConfigLoader.load_config(config_file)
+        assert "Invalid configuration" in str(exc_info.value)
+
+
+class TestResolveLLMConfig:
+    """Tests for LLM config resolution with priority."""
+
+    def test_defaults_when_no_config(self) -> None:
+        """Returns defaults when no config file."""
+        result = ConfigLoader.resolve_llm_config(None, "judge")
+
+        assert result.provider == "ollama"
+        assert result.model == "llama3.2"
+        assert result.temperature == 0.0
+        assert result.max_tokens == 4096
+
+    def test_shared_llm_config_used(self) -> None:
+        """Shared llm config is used when component-specific not provided."""
+        file_config = FileConfig(
+            llm=LLMConfig(provider="openai", model="gpt-4", temperature=0.7)
+        )
+
+        result = ConfigLoader.resolve_llm_config(file_config, "judge")
+
+        assert result.provider == "openai"
+        assert result.model == "gpt-4"
+        assert result.temperature == 0.7
+
+    def test_component_overrides_shared(self) -> None:
+        """Component-specific config overrides shared llm config."""
+        file_config = FileConfig(
+            llm=LLMConfig(provider="openai", model="gpt-4"),
+            judge=LLMConfig(provider="openai", model="gpt-4o"),
+        )
+
+        result = ConfigLoader.resolve_llm_config(file_config, "judge")
+
+        assert result.model == "gpt-4o"
+
+    def test_cli_overrides_file_config(self) -> None:
+        """CLI arguments override file config."""
+        file_config = FileConfig(
+            llm=LLMConfig(provider="openai", model="gpt-4")
+        )
+        cli_overrides = CLIOverrides(model="gpt-3.5-turbo")
+
+        result = ConfigLoader.resolve_llm_config(file_config, "judge", cli_overrides)
+
+        assert result.model == "gpt-3.5-turbo"
+        assert result.provider == "openai"  # From file config
+
+    def test_cli_overrides_all_fields(self) -> None:
+        """CLI can override all fields."""
+        file_config = FileConfig(
+            llm=LLMConfig(provider="openai", model="gpt-4")
+        )
+        cli_overrides = CLIOverrides(
+            provider="ollama",
+            model="llama3.2",
+            base_url="http://localhost:11434",
+            temperature=0.5,
+            max_tokens=2048,
+            api_key="cli-key",
+        )
+
+        result = ConfigLoader.resolve_llm_config(file_config, "judge", cli_overrides)
+
+        assert result.provider == "ollama"
+        assert result.model == "llama3.2"
+        assert result.base_url == "http://localhost:11434"
+        assert result.temperature == 0.5
+        assert result.max_tokens == 2048
+        assert result.api_key is not None
+        assert result.api_key.get_secret_value() == "cli-key"
+
+    def test_different_components_can_have_different_configs(self) -> None:
+        """Judge and synthetic_user can have different configurations."""
+        file_config = FileConfig(
+            llm=LLMConfig(provider="openai", model="gpt-4"),
+            judge=LLMConfig(provider="openai", model="gpt-4o"),
+            synthetic_user=LLMConfig(provider="ollama", model="llama3.2"),
+        )
+
+        judge_config = ConfigLoader.resolve_llm_config(file_config, "judge")
+        user_config = ConfigLoader.resolve_llm_config(file_config, "synthetic_user")
+
+        assert judge_config.provider == "openai"
+        assert judge_config.model == "gpt-4o"
+        assert user_config.provider == "ollama"
+        assert user_config.model == "llama3.2"
+
+    def test_api_key_from_file_config(self) -> None:
+        """API key from file config is used."""
+        file_config = FileConfig(
+            llm=LLMConfig(
+                provider="openai",
+                model="gpt-4",
+                api_key=SecretStr("file-api-key"),
+            )
+        )
+
+        result = ConfigLoader.resolve_llm_config(file_config, "judge")
+
+        assert result.api_key is not None
+        assert result.api_key.get_secret_value() == "file-api-key"
+
+
+class TestResolveOrchestratorConfig:
+    """Tests for orchestrator config resolution."""
+
+    def test_defaults_when_no_config(self) -> None:
+        """Returns defaults when no config file."""
+        result = ConfigLoader.resolve_orchestrator_config(None)
+
+        assert result.max_turns == 10
+        assert result.turn_timeout_seconds == 30.0
+        assert result.loop_detection_threshold == 3
+
+    def test_file_config_used(self) -> None:
+        """File config values are used."""
+        file_config = FileConfig(
+            orchestrator=OrchestratorConfig(
+                max_turns=20,
+                turn_timeout_seconds=60.0,
+                loop_detection_threshold=5,
+            )
+        )
+
+        result = ConfigLoader.resolve_orchestrator_config(file_config)
+
+        assert result.max_turns == 20
+        assert result.turn_timeout_seconds == 60.0
+        assert result.loop_detection_threshold == 5
+
+    def test_cli_overrides_file_config(self) -> None:
+        """CLI arguments override file config."""
+        file_config = FileConfig(
+            orchestrator=OrchestratorConfig(max_turns=20, turn_timeout_seconds=60.0)
+        )
+
+        result = ConfigLoader.resolve_orchestrator_config(
+            file_config, cli_max_turns=5, cli_timeout=15.0
+        )
+
+        assert result.max_turns == 5
+        assert result.turn_timeout_seconds == 15.0
+
+
+class TestResolveResultsConfig:
+    """Tests for results config resolution."""
+
+    def test_defaults_when_no_config(self) -> None:
+        """Returns defaults when no config file."""
+        result = ConfigLoader.resolve_results_config(None)
+
+        assert result.save is True
+        assert result.dir == "test-results"
+
+    def test_file_config_used(self) -> None:
+        """File config values are used."""
+        file_config = FileConfig(
+            results=ResultsConfig(save=False, dir="custom-results")
+        )
+
+        result = ConfigLoader.resolve_results_config(file_config)
+
+        assert result.save is False
+        assert result.dir == "custom-results"
+
+    def test_cli_overrides_file_config(self) -> None:
+        """CLI arguments override file config."""
+        file_config = FileConfig(
+            results=ResultsConfig(save=True, dir="file-results")
+        )
+
+        result = ConfigLoader.resolve_results_config(
+            file_config, cli_save=False, cli_dir="cli-results"
+        )
+
+        assert result.save is False
+        assert result.dir == "cli-results"
+
+
+class TestResolveAgentConfig:
+    """Tests for agent config resolution."""
+
+    def test_defaults_when_no_config(self) -> None:
+        """Returns defaults when no config file."""
+        result = ConfigLoader.resolve_agent_config(None)
+
+        assert result.type == "simple"
+        assert result.factory is None
+
+    def test_file_config_used(self) -> None:
+        """File config values are used."""
+        file_config = FileConfig(
+            agent=AgentConfig(type="adk", factory="path/to/agent.py")
+        )
+
+        result = ConfigLoader.resolve_agent_config(file_config)
+
+        assert result.type == "adk"
+        assert result.factory == "path/to/agent.py"
+
+    def test_cli_overrides_file_config(self) -> None:
+        """CLI arguments override file config."""
+        file_config = FileConfig(
+            agent=AgentConfig(type="simple", factory=None)
+        )
+
+        result = ConfigLoader.resolve_agent_config(
+            file_config,
+            cli_agent_type="adk",
+            cli_agent_factory="cli/agent.py",
+        )
+
+        assert result.type == "adk"
+        assert result.factory == "cli/agent.py"
+
+    def test_partial_cli_override(self) -> None:
+        """CLI can override individual fields."""
+        file_config = FileConfig(
+            agent=AgentConfig(type="adk", factory="config/agent.py")
+        )
+
+        # Only override factory, keep type from config
+        result = ConfigLoader.resolve_agent_config(
+            file_config,
+            cli_agent_factory="cli/agent.py",
+        )
+
+        assert result.type == "adk"  # From config
+        assert result.factory == "cli/agent.py"  # From CLI
+
+    def test_simple_agent_no_factory_required(self) -> None:
+        """Simple agent type doesn't require factory."""
+        result = ConfigLoader.resolve_agent_config(
+            None,
+            cli_agent_type="simple",
+        )
+
+        assert result.type == "simple"
+        assert result.factory is None
+
+
+class TestFullIntegration:
+    """Integration tests for end-to-end config loading."""
+
+    def test_full_config_file_loading(self, tmp_path: Path) -> None:
+        """Full config file is loaded and resolved correctly."""
+        config_file = tmp_path / "mcprobe.yaml"
+        config_file.write_text(
+            "agent:\n"
+            "  type: adk\n"
+            "  factory: my_agent.py\n"
+            "\n"
+            "llm:\n"
+            "  provider: openai\n"
+            "  model: gpt-4\n"
+            "  base_url: ${API_URL:-https://api.openai.com/v1}\n"
+            "  api_key: ${OPENAI_API_KEY}\n"
+            "  temperature: 0.0\n"
+            "  max_tokens: 4096\n"
+            "\n"
+            "judge:\n"
+            "  provider: openai\n"
+            "  model: gpt-4o\n"
+            "\n"
+            "synthetic_user:\n"
+            "  provider: ollama\n"
+            "  model: llama3.2\n"
+            "  base_url: http://localhost:11434\n"
+            "\n"
+            "orchestrator:\n"
+            "  max_turns: 15\n"
+            "  turn_timeout_seconds: 45.0\n"
+            "\n"
+            "results:\n"
+            "  save: true\n"
+            "  dir: my-test-results\n"
+        )
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key-123"}):
+            file_config = ConfigLoader.load_config(config_file)
+
+        assert file_config is not None
+
+        # Resolve agent config - should use agent settings
+        agent_config = ConfigLoader.resolve_agent_config(file_config)
+        assert agent_config.type == "adk"
+        assert agent_config.factory == "my_agent.py"
+
+        # Resolve judge config - should use judge-specific settings
+        judge_config = ConfigLoader.resolve_llm_config(file_config, "judge")
+        assert judge_config.provider == "openai"
+        assert judge_config.model == "gpt-4o"
+        assert judge_config.api_key is not None
+        assert judge_config.api_key.get_secret_value() == "test-key-123"
+
+        # Resolve synthetic_user config - should use synthetic_user-specific settings
+        user_config = ConfigLoader.resolve_llm_config(file_config, "synthetic_user")
+        assert user_config.provider == "ollama"
+        assert user_config.model == "llama3.2"
+        assert user_config.base_url == "http://localhost:11434"
+
+        # Resolve orchestrator config
+        orch_config = ConfigLoader.resolve_orchestrator_config(file_config)
+        assert orch_config.max_turns == 15
+        assert orch_config.turn_timeout_seconds == 45.0
+
+        # Resolve results config
+        results_config = ConfigLoader.resolve_results_config(file_config)
+        assert results_config.save is True
+        assert results_config.dir == "my-test-results"


### PR DESCRIPTION
## Summary

Implements GitHub Issue #11: Add configuration file support for MCProbe.

- Add YAML config file support (`mcprobe.yaml` or `.mcprobe.yaml`)
- Support environment variable interpolation (`${VAR}` and `${VAR:-default}` syntax)
- Add agent configuration to config file (`type`, `factory`)
- Add `--config`/`-c` and `--provider`/`-p` CLI options
- Add `--mcprobe-config` and `--mcprobe-provider` pytest options
- Support separate LLM configs for judge and synthetic_user components
- CLI arguments override config file values
- Add comprehensive unit tests (43 tests for config loading)
- Update documentation with config file format and examples

### Example Config File

```yaml
# mcprobe.yaml
agent:
  type: adk
  factory: my_agent.py

llm:
  provider: openai
  model: gpt-4
  api_key: ${OPENAI_API_KEY}

judge:
  provider: openai
  model: gpt-4o

synthetic_user:
  provider: ollama
  model: llama3.2
  base_url: https://ollama.example.com

orchestrator:
  max_turns: 10
  turn_timeout_seconds: 30.0

results:
  save: true
  dir: test-results
```

## Test plan

- [x] All 193 unit tests pass
- [x] `ruff check` passes
- [x] `mypy` type checking passes
- [x] Config file discovery works (mcprobe.yaml, .mcprobe.yaml)
- [x] Environment variable interpolation works
- [x] CLI overrides work correctly
- [x] Agent config resolves from file and CLI
- [x] Documentation updated

Closes #11