### PR TITLE
Fix timezone comparison in report --since filtering

### DIFF
--- a/src/mcprobe/persistence/loader.py
+++ b/src/mcprobe/persistence/loader.py
@@ -105,7 +105,9 @@ class ResultLoader:
         if scenario_name:
             entries = [e for e in entries if e.scenario_name == scenario_name]
         if since:
-            entries = [e for e in entries if e.timestamp >= since]
+            # Normalize timezone - strip tzinfo from since if entry timestamps are naive
+            since_cmp = since.replace(tzinfo=None) if since.tzinfo else since
+            entries = [e for e in entries if e.timestamp >= since_cmp]
 
         # Sort by timestamp descending
         entries.sort(key=lambda e: e.timestamp, reverse=True)


### PR DESCRIPTION
## Problem

The `--since` option creates timezone-aware datetimes (UTC) but stored entry timestamps are timezone-naive. This caused a `TypeError: can't compare offset-naive and offset-aware datetimes` when filtering results.

## Solution

Strip timezone info from the `since` datetime before comparing with stored entry timestamps.

## Test plan

- [x] Existing tests pass
- [x] Linting passes