### PR TITLE
Fix --since to convert UTC to local time before comparison

### DIFF
--- a/src/mcprobe/persistence/loader.py
+++ b/src/mcprobe/persistence/loader.py
@@ -105,8 +105,8 @@ class ResultLoader:
         if scenario_name:
             entries = [e for e in entries if e.scenario_name == scenario_name]
         if since:
-            # Normalize timezone - strip tzinfo from since if entry timestamps are naive
-            since_cmp = since.replace(tzinfo=None) if since.tzinfo else since
+            # Convert UTC since to local time for comparison with naive local timestamps
+            since_cmp = since.astimezone().replace(tzinfo=None) if since.tzinfo else since
             entries = [e for e in entries if e.timestamp >= since_cmp]
 
         # Sort by timestamp descending


### PR DESCRIPTION
## Problem

The `--since` option creates UTC timestamps, but stored results use naive local timestamps. The previous fix just stripped tzinfo, but this caused comparisons to fail across timezone boundaries.

Example: At 18:48 PST on Jan 18:
- `--since 1h` = `01:50 UTC on Jan 19` (after stripping tz: `2026-01-19T01:50`)
- Stored timestamp: `2026-01-18T18:48` (naive local)
- Comparison: `18:48 Jan 18` < `01:50 Jan 19` = EXCLUDED (wrong!)

## Solution

Convert UTC to local time using `astimezone()` before stripping tzinfo.

## Test plan

- [x] Linting passes