### PR TITLE
Make test runs collapsible in HTML report

### DIFF
--- a/src/mcprobe/reporting/templates/styles.css
+++ b/src/mcprobe/reporting/templates/styles.css
@@ -124,47 +124,77 @@ section h2 {
     border-color: var(--color-primary);
 }
 
-/* Test Run Groups */
-.test-run {
-    margin-bottom: 1.5rem;
+/* Test Run Groups (Collapsible) */
+details.test-run {
+    margin-bottom: 1rem;
     border: 1px solid var(--color-border);
     border-radius: 8px;
     overflow: hidden;
+    background: white;
 }
 
-.run-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.75rem 1rem;
-    background: var(--color-bg);
-    border-bottom: 1px solid var(--color-border);
-}
-
-.run-header.pass {
-    background: rgba(40, 167, 69, 0.1);
+details.test-run.pass {
     border-left: 4px solid var(--color-pass);
 }
 
-.run-header.fail {
-    background: rgba(220, 53, 69, 0.1);
+details.test-run.fail {
     border-left: 4px solid var(--color-fail);
+}
+
+details.test-run > summary.run-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+    background: var(--color-bg);
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+}
+
+details.test-run > summary.run-header::-webkit-details-marker {
+    display: none;
+}
+
+details.test-run.pass > summary.run-header {
+    background: rgba(40, 167, 69, 0.1);
+}
+
+details.test-run.fail > summary.run-header {
+    background: rgba(220, 53, 69, 0.1);
+}
+
+details.test-run > summary.run-header:hover {
+    filter: brightness(0.95);
+}
+
+details.test-run > summary.run-header::before {
+    content: "▶";
+    margin-right: 0.75rem;
+    font-size: 0.75rem;
+    transition: transform 0.2s;
+}
+
+details.test-run[open] > summary.run-header::before {
+    transform: rotate(90deg);
 }
 
 .run-info {
     display: flex;
     gap: 1rem;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .run-id {
     font-weight: 600;
     font-family: monospace;
+    font-size: 0.95rem;
 }
 
 .run-timestamp {
     color: var(--color-text-muted);
-    font-size: 0.9rem;
+    font-size: 0.85rem;
 }
 
 .run-model {
@@ -181,12 +211,22 @@ section h2 {
     font-size: 0.9rem;
 }
 
+.run-total {
+    color: var(--color-text-muted);
+}
+
 .run-passed {
     color: var(--color-pass);
+    font-weight: 500;
 }
 
 .run-failed {
     color: var(--color-fail);
+    font-weight: 500;
+}
+
+.run-content {
+    padding: 0;
 }
 
 /* Scenarios Table */
@@ -243,12 +283,12 @@ section h2 {
     margin-right: 0.25rem;
 }
 
-/* Details */
-details {
+/* Scenario Details (not test-run details) */
+td details {
     cursor: pointer;
 }
 
-details summary {
+td details summary {
     color: var(--color-primary);
     font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary

Makes each test run in the HTML report collapsible so users can:
- Collapse test runs they don't want to see
- Focus on specific test runs
- Better navigate reports with multiple test runs

## Changes

- Wrap each test run in a `<details>` element
- First/most recent run opens by default, others are collapsed
- Visual arrow indicator shows expand/collapse state
- Show total test count in run header alongside pass/fail stats
- Update CSS for proper collapsible styling

## Test plan
- [x] Existing tests pass
- [ ] Generate report with multiple runs and verify collapsing works
- [ ] Verify first run is expanded by default