### PR TITLE
Use session-level run_id to group tests from same pytest run

### DIFF
--- a/src/mcprobe/pytest_plugin/plugin.py
+++ b/src/mcprobe/pytest_plugin/plugin.py
@@ -226,8 +226,11 @@ class MCProbeItem(pytest.Item):
         git_commit = self._get_git_commit()
         git_branch = self._get_git_branch()
 
+        # Use the session-level run_id so all tests in this run are grouped together
+        run_id = getattr(self.config, "mcprobe_run_id", str(uuid.uuid4()))
+
         result = TestRunResult(
-            run_id=str(uuid.uuid4()),
+            run_id=run_id,
             timestamp=datetime.now(),
             scenario_name=self.scenario.name,
             scenario_file=str(self.path),
@@ -464,6 +467,8 @@ def pytest_configure(config: pytest.Config) -> None:
         "filterwarnings",
         "ignore::pytest.PytestUnknownMarkWarning",
     )
+    # Generate a single run_id for the entire pytest session
+    config.mcprobe_run_id = str(uuid.uuid4())  # type: ignore[attr-defined]
 
 
 def pytest_collection_modifyitems(


### PR DESCRIPTION
## Summary

Fixes an issue where each test was treated as a separate "test run" in HTML reports.

## Problem

Previously, each test generated its own `uuid.uuid4()` for `run_id`, causing:
- Reports showing N test runs when running N tests
- Each test appearing as its own collapsed section
- No logical grouping of tests that ran together

## Solution

- Generate a single `run_id` in `pytest_configure` that's stored on the config object
- All tests in the session now share this `run_id`
- Tests that run together are properly grouped in the HTML report

## Test plan
- [x] Unit tests pass
- [ ] Run multiple scenario tests and verify they appear under a single run in the report