### PR TITLE
Suppress noisy third-party warnings in pytest output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,14 @@ addopts = "-v --tb=short"
 markers = [
     "e2e: end-to-end tests requiring external services (Ollama)",
 ]
+filterwarnings = [
+    # Ignore deprecation warnings from Google ADK/GenAI libraries
+    "ignore::DeprecationWarning:google.adk.*",
+    "ignore::DeprecationWarning:google.genai.*",
+    "ignore::UserWarning:google.adk.*",
+    # Ignore pytest collection warnings for Pydantic models named Test*
+    "ignore::pytest.PytestCollectionWarning",
+]
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
## Summary
- Add pytest `filterwarnings` configuration to suppress third-party warning noise

## Changes
Filter out:
- Deprecation warnings from Google ADK/GenAI libraries
- User warnings from Google ADK experimental features
- Pytest collection warnings for Pydantic models named `Test*`

## Before
```
======================= 1 passed, 83 warnings in 47.76s ========================
```

## After
```
============================= 241 passed in 0.48s ==============================
```

## Test plan
- [x] All unit tests pass with clean output

Fixes #31