### PR TITLE
Capture agent prompt and tool schemas in MCP server

### DIFF
--- a/src/mcprobe/agents/base.py
+++ b/src/mcprobe/agents/base.py
@@ -41,7 +41,7 @@ class AgentUnderTest(ABC):
         ...
 
     @abstractmethod
-    def get_available_tools(self) -> list[dict[str, object]]:
+    async def get_available_tools(self) -> list[dict[str, object]]:
         """Return the tool schemas available to this agent.
 
         Returns:

--- a/src/mcprobe/agents/simple.py
+++ b/src/mcprobe/agents/simple.py
@@ -90,7 +90,7 @@ class SimpleLLMAgent(AgentUnderTest):
         if self._system_prompt:
             self._conversation_history.append(Message(role="system", content=self._system_prompt))
 
-    def get_available_tools(self) -> list[dict[str, object]]:
+    async def get_available_tools(self) -> list[dict[str, object]]:
         """Return empty list - simple agent has no tools."""
         return []
 


### PR DESCRIPTION
## Summary
- Capture agent system prompt via `agent.get_system_prompt()`
- Capture MCP tool schemas via `agent.get_available_tools()`
- Compute SHA256 hashes for change detection
- Include all fields in TestRunResult

This fixes reports generated via the MCP server showing "No system prompt captured" and "No MCP tool schemas captured".

Closes #42

## Test plan
- [ ] Run scenario via MCP server
- [ ] Generate report
- [ ] Verify Configuration Details section shows prompt and schemas