### PR TITLE
Improve HTML report rendering, tool call display, and fix empty schemas (#48, #49, #50)

### DIFF
--- a/src/mcprobe/judge/judge.py
+++ b/src/mcprobe/judge/judge.py
@@ -138,6 +138,7 @@ class ConversationJudge:
         tool_usage_dict = {
             "required_tools": eval_config.tool_usage.required_tools,
             "required_tools_used": required_used if isinstance(required_used, list) else [],
+            "optional_tools": eval_config.tool_usage.optional_tools,
             "prohibited_tools": eval_config.tool_usage.prohibited_tools,
             "prohibited_tools_used": prohibited_used if isinstance(prohibited_used, list) else [],
             "all_required_used": tool_usage.get("all_required_used", False),

--- a/src/mcprobe/reporting/templates/styles.css
+++ b/src/mcprobe/reporting/templates/styles.css
@@ -709,6 +709,71 @@ details.tool-call .latency {
     font-size: 0.8rem;
 }
 
+/* Tool Categories */
+.tool-category {
+    margin-bottom: 1rem;
+    padding: 0.75rem;
+    border-radius: 4px;
+    background: white;
+    border: 1px solid var(--color-border);
+}
+
+.tool-category:last-child {
+    margin-bottom: 0;
+}
+
+.tool-category h5 {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.tool-category.required {
+    border-left: 3px solid var(--color-primary);
+}
+
+.tool-category.required.pass h5 {
+    color: var(--color-pass);
+}
+
+.tool-category.required.fail h5 {
+    color: var(--color-fail);
+}
+
+.tool-category.required.fail {
+    border-left-color: var(--color-fail);
+    background: rgba(220, 53, 69, 0.05);
+}
+
+.tool-category.optional {
+    border-left: 3px solid #6c757d;
+}
+
+.tool-category.optional h5 {
+    color: #6c757d;
+}
+
+.tool-category.unexpected {
+    border-left: 3px solid #ffc107;
+    background: rgba(255, 193, 7, 0.1);
+}
+
+.tool-category.unexpected h5 {
+    color: #856404;
+}
+
+.tool-category p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+
+.tool-category .missing-tools {
+    color: var(--color-fail);
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+}
+
 /* Footer */
 footer {
     text-align: center;


### PR DESCRIPTION
## Summary
- Render Judge LLM reasoning and Synthetic User messages as Markdown using the existing marked.js library
- Categorize tool calls into Required, Optional, and Unexpected sections with clear visual indicators
- Fix MCP server `run_scenario` returning empty tool schemas

## Changes

### Markdown Rendering (#48)
- Changed Judge LLM reasoning from plain text `<p>` tags to `<div class="markdown-content">` for proper markdown rendering
- Changed Synthetic User (role="user") turns to use markdown rendering, same as agent under test output

### Tool Call Categorization (#49)
- Rewrote `_build_tool_calls_html` to categorize tools by:
  - **Required** - tools that must be called (shows pass/fail status and missing tools)
  - **Optional** - tools from the scenario's optional_tools list
  - **Unexpected** - any other tools (highlighted with yellow background)
- Added `optional_tools` to the judgment result's `tool_usage_dict` so the report has access to it
- Added CSS styling for tool categories with visual differentiation

### MCP Server Tool Schema Fix (#50)
- Added `_extract_tool_schemas` helper function that:
  1. First tries to extract schemas from `mcp_server` config (most reliable)
  2. Falls back to `agent.get_available_tools()` for ADK agents without mcp_server config
- This fixes reports generated via MCP server showing empty `{}` schemas

## Test plan
- [x] All 255 unit tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Manual verification with ADK agent - tool schemas now display correctly

Closes #48
Closes #49
Closes #50