### PR TITLE
Add customizable prompts and per-scenario LLM config overrides (#52)

### DIFF
--- a/src/mcprobe/judge/judge.py
+++ b/src/mcprobe/judge/judge.py
@@ -68,13 +68,19 @@ class ConversationJudge:
     according to the test scenario's evaluation criteria.
     """
 
-    def __init__(self, provider: LLMProvider) -> None:
+    def __init__(
+        self,
+        provider: LLMProvider,
+        extra_instructions: str | None = None,
+    ) -> None:
         """Initialize the conversation judge.
 
         Args:
             provider: LLM provider to use for evaluation.
+            extra_instructions: Additional instructions to append to judge prompts.
         """
         self._provider = provider
+        self._extra_instructions = extra_instructions
 
     async def evaluate(
         self,
@@ -93,7 +99,7 @@ class ConversationJudge:
         Raises:
             JudgmentError: If evaluation fails.
         """
-        prompt = build_judge_prompt(scenario, result)
+        prompt = build_judge_prompt(scenario, result, self._extra_instructions)
 
         try:
             evaluation = await self._provider.generate_structured(
@@ -222,7 +228,7 @@ class ConversationJudge:
         Raises:
             JudgmentError: If evaluation fails.
         """
-        prompt = build_criteria_check_prompt(scenario, turns)
+        prompt = build_criteria_check_prompt(scenario, turns, self._extra_instructions)
 
         try:
             result = await self._provider.generate_structured(

--- a/src/mcprobe/judge/prompts.py
+++ b/src/mcprobe/judge/prompts.py
@@ -239,12 +239,14 @@ CRITERIA_CHECK_RESULT_TRUNCATE_LEN = 500
 def build_criteria_check_prompt(
     scenario: TestScenario,
     turns: list[ConversationTurn],
+    extra_instructions: str | None = None,
 ) -> str:
     """Build the prompt for checking criteria mid-conversation.
 
     Args:
         scenario: Test scenario with evaluation criteria.
         turns: Conversation turns so far.
+        extra_instructions: Additional instructions to append to the prompt.
 
     Returns:
         Formatted criteria check prompt string.
@@ -254,7 +256,7 @@ def build_criteria_check_prompt(
 
     # Use truncated tool results for mid-conversation checks
     # The assistant's response text contains the relevant info for criteria
-    return CRITERIA_CHECK_PROMPT.format(
+    prompt = CRITERIA_CHECK_PROMPT.format(
         user_persona=user_config.persona,
         initial_query=user_config.initial_query,
         correctness_criteria=format_criteria_list(evaluation.correctness_criteria),
@@ -263,16 +265,23 @@ def build_criteria_check_prompt(
         ),
     )
 
+    if extra_instructions:
+        prompt += f"\n\n## Additional Instructions\n{extra_instructions}"
+
+    return prompt
+
 
 def build_judge_prompt(
     scenario: TestScenario,
     result: ConversationResult,
+    extra_instructions: str | None = None,
 ) -> str:
     """Build the evaluation prompt for the judge.
 
     Args:
         scenario: Test scenario with evaluation criteria.
         result: Conversation result to evaluate.
+        extra_instructions: Additional instructions to append to the prompt.
 
     Returns:
         Formatted judge prompt string.
@@ -288,7 +297,7 @@ def build_judge_prompt(
     max_tool_calls = evaluation.efficiency.max_tool_calls or "No limit"
     max_turns = evaluation.efficiency.max_conversation_turns or "No limit"
 
-    return JUDGE_EVALUATION_PROMPT.format(
+    prompt = JUDGE_EVALUATION_PROMPT.format(
         scenario_description=scenario.description,
         user_persona=user_config.persona,
         initial_query=user_config.initial_query,
@@ -302,3 +311,8 @@ def build_judge_prompt(
         max_tool_calls=max_tool_calls,
         max_turns=max_turns,
     )
+
+    if extra_instructions:
+        prompt += f"\n\n## Additional Instructions\n{extra_instructions}"
+
+    return prompt

--- a/src/mcprobe/models/config.py
+++ b/src/mcprobe/models/config.py
@@ -30,6 +30,8 @@ class LLMConfig(BaseModel):
     context_size: int | None = Field(default=None, ge=1024)
     # Reasoning/thinking effort level (maps to provider-specific options)
     reasoning: Literal["low", "medium", "high"] | None = None
+    # Extra instructions to append to the system prompt (for judge/synthetic_user)
+    extra_instructions: str | None = None
 
 
 class OrchestratorConfig(BaseModel):

--- a/src/mcprobe/models/scenario.py
+++ b/src/mcprobe/models/scenario.py
@@ -91,6 +91,24 @@ class EvaluationConfig(BaseModel):
     efficiency: EfficiencyConfig = Field(default_factory=EfficiencyConfig)
 
 
+class ScenarioLLMOverride(BaseModel):
+    """Per-scenario LLM configuration overrides.
+
+    All fields are optional - only set values will override global config.
+    """
+
+    model: str | None = None
+    temperature: float | None = None
+    extra_instructions: str | None = None
+
+
+class ScenarioConfig(BaseModel):
+    """Optional per-scenario configuration overrides."""
+
+    judge: ScenarioLLMOverride | None = None
+    synthetic_user: ScenarioLLMOverride | None = None
+
+
 class TestScenario(BaseModel):
     """Complete test scenario definition."""
 
@@ -99,6 +117,7 @@ class TestScenario(BaseModel):
     synthetic_user: SyntheticUserConfig
     evaluation: EvaluationConfig
     tags: list[str] = Field(default_factory=list)
+    config: ScenarioConfig | None = None  # Optional per-scenario overrides
 
     @field_validator("name")
     @classmethod

--- a/src/mcprobe/synthetic_user/prompts.py
+++ b/src/mcprobe/synthetic_user/prompts.py
@@ -91,11 +91,15 @@ PATIENCE_THRESHOLDS = {
 }
 
 
-def build_synthetic_user_prompt(config: SyntheticUserConfig) -> str:
+def build_synthetic_user_prompt(
+    config: SyntheticUserConfig,
+    extra_instructions: str | None = None,
+) -> str:
     """Build the system prompt for the synthetic user.
 
     Args:
         config: Synthetic user configuration from the scenario.
+        extra_instructions: Additional instructions to append to the prompt.
 
     Returns:
         Formatted system prompt string.
@@ -110,7 +114,7 @@ def build_synthetic_user_prompt(config: SyntheticUserConfig) -> str:
 
     patience_threshold = PATIENCE_THRESHOLDS.get(traits.patience.value, 3)
 
-    return SYNTHETIC_USER_SYSTEM_PROMPT.format(
+    prompt = SYNTHETIC_USER_SYSTEM_PROMPT.format(
         persona=config.persona,
         initial_query=config.initial_query,
         known_facts=known_facts_str,
@@ -120,3 +124,8 @@ def build_synthetic_user_prompt(config: SyntheticUserConfig) -> str:
         verbosity=traits.verbosity.value,
         expertise=traits.expertise.value,
     )
+
+    if extra_instructions:
+        prompt += f"\n\n## Additional Instructions\n{extra_instructions}"
+
+    return prompt

--- a/src/mcprobe/synthetic_user/user.py
+++ b/src/mcprobe/synthetic_user/user.py
@@ -21,16 +21,18 @@ class SyntheticUserLLM:
         self,
         provider: LLMProvider,
         config: SyntheticUserConfig,
+        extra_instructions: str | None = None,
     ) -> None:
         """Initialize the synthetic user.
 
         Args:
             provider: LLM provider to use for generating responses.
             config: Synthetic user configuration from the test scenario.
+            extra_instructions: Additional instructions to append to the system prompt.
         """
         self._provider = provider
         self._config = config
-        self._system_prompt = build_synthetic_user_prompt(config)
+        self._system_prompt = build_synthetic_user_prompt(config, extra_instructions)
         self._conversation_history: list[Message] = [
             Message(role="system", content=self._system_prompt)
         ]


### PR DESCRIPTION
## Summary

Add the ability to customize judge and synthetic user behavior through:
- `extra_instructions` that augment the default prompts
- Per-scenario LLM configuration overrides
- Separate LLM configs for judge and synthetic_user

## Configuration Priority (highest to lowest)

1. CLI arguments
2. Scenario-level config (from scenario YAML)
3. Component-specific config (`judge:`, `synthetic_user:`)
4. Shared LLM config (`llm:`)
5. Defaults

**Note:** `extra_instructions` are **appended** from all levels (not replaced).

## Example Usage

### Global Config (`mcprobe.yaml`)

```yaml
llm:
  provider: openai
  model: gpt-4o

judge:
  model: gpt-4o-mini  # Use cheaper model for judging
  extra_instructions: |
    Be lenient about formatting differences.
    Consider partial credit for directionally correct answers.

synthetic_user:
  model: gpt-4o
  extra_instructions: |
    Push back firmly on vague answers.
```

### Per-Scenario Override

```yaml
name: Complex Financial Analysis
description: Tests multi-step calculations

config:
  judge:
    model: gpt-4o  # Need smarter model for this one
    extra_instructions: |
      This scenario requires exact numerical precision.
  synthetic_user:
    extra_instructions: |
      You are a CFO who expects exact figures.

synthetic_user:
  persona: A CFO reviewing quarterly reports
  initial_query: What was our Q3 revenue growth?

evaluation:
  correctness_criteria:
    - Provides exact revenue figures
```

## Changes

- Added `extra_instructions` field to `LLMConfig` model
- Added `ScenarioLLMOverride` and `ScenarioConfig` to scenario model
- Added optional `config` section to `TestScenario`
- Updated `resolve_llm_config` to handle scenario-level overrides
- Updated prompt builders to append extra_instructions
- Updated pytest plugin, MCP server, and CLI to pass scenario configs
- Added `LLMDefaults` dataclass to avoid too-many-arguments lint issue

## Test plan

- [x] All 255 unit tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Manual testing with scenario overrides

Closes #52