### PR TITLE
Fix tool call ordering in transcript and add timestamps (#54)

### DIFF
--- a/src/mcprobe/models/conversation.py
+++ b/src/mcprobe/models/conversation.py
@@ -17,6 +17,8 @@ class ToolCall(BaseModel):
     result: Any
     latency_ms: float
     error: str | None = None
+    called_at: float | None = None  # Epoch time when tool was called
+    responded_at: float | None = None  # Epoch time when tool responded
 
 
 class AgentResponse(BaseModel):


### PR DESCRIPTION
## Problem

The judge LLM was incorrectly detecting data fabrication because the conversation transcript showed the agent's text response BEFORE the tool call results.

**What the judge saw (incorrect ordering):**
```
[ASSISTANT]: The revenue is $1.5M based on the data...
  -> Tool call: get_revenue()
     Result: {"revenue": 1500000}
```

The judge thought: "The agent stated $1.5M before the tool returned that value - fabrication!"

## Solution

1. **Add timestamps to ToolCall model** (`called_at`, `responded_at`)
2. **Update ADK agent** to capture precise timing of tool calls
3. **Reorder transcript** to show tool calls before response text
4. **Add timestamps** to all transcript entries

**New format (correct ordering with timestamps):**
```
[ASSISTANT] @ 10:30:45.123:
  -> Tool called @ 10:30:45.100: get_revenue({})
     Result @ 10:30:45.200: {"revenue": 1500000}
  Response: The revenue is $1.5M based on the data...
```

Now it's unambiguous that:
- Tool was called at 10:30:45.100
- Tool responded at 10:30:45.200
- Agent synthesized response using those results

## Backwards Compatibility

- New `called_at` and `responded_at` fields are optional (`float | None = None`)
- Existing stored results load successfully (Pydantic uses `None` defaults)
- Timestamp formatter handles `None` by displaying "N/A"

## Test plan

- [x] All 255 unit tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Backwards compatibility verified - won't break report generation

Closes #54