### PR TITLE
Fix empty agent response in ADK agent when tools are used

### DIFF
--- a/src/mcprobe/agents/adk.py
+++ b/src/mcprobe/agents/adk.py
@@ -134,8 +134,9 @@ class GeminiADKAgent(AgentUnderTest):
                         self._process_function_responses(responses, pending_calls)
                     )
 
-                # Get final response text
-                if event.is_final_response() and event.content and event.content.parts:
+                # Capture text from any event with text content
+                # (not just final response - text may come in earlier events when tools are used)
+                if event.content and event.content.parts:
                     for part in event.content.parts:
                         if hasattr(part, "text") and part.text:
                             response_text += part.text

--- a/src/mcprobe/synthetic_user/user.py
+++ b/src/mcprobe/synthetic_user/user.py
@@ -62,6 +62,13 @@ class SyntheticUserLLM:
         Raises:
             OrchestrationError: If the LLM call fails.
         """
+        # Handle empty agent responses - ask for clarification instead of confusing the LLM
+        if not assistant_message.strip():
+            response = "I didn't receive a response. Could you try again?"
+            self._conversation_history.append(Message(role="assistant", content=assistant_message))
+            self._conversation_history.append(Message(role="user", content=response))
+            return UserResponse(message=response, tokens_used=0)
+
         # Add assistant message to history
         self._conversation_history.append(Message(role="assistant", content=assistant_message))
 


### PR DESCRIPTION
## Summary

Two-part fix for empty agent responses:

1. **ADK Agent**: Capture text from all events with text content, not just events marked as `is_final_response()`. When tools are used, the response text may come in earlier events.

2. **Synthetic User**: When agent returns empty response, ask for clarification ("I didn't receive a response. Could you try again?") instead of passing empty content to the LLM - which would confuse it and trigger the fallback "Thanks" message that masks the bug.

## Root Cause

### Part 1: ADK Agent
The ADK agent's `send_message` method checked `event.is_final_response()` before extracting text. When an ADK agent calls tools, the actual response text may NOT be in the final event.

### Part 2: Synthetic User
When the synthetic user LLM received an empty agent message, it got confused and returned an empty response. The code then defaulted to "Thanks, that answers my question." - masking the bug.

## Test plan

- [x] Unit tests pass (260 tests)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Added tests for empty agent response handling
- [ ] Manual testing: Re-run scenarios that had empty responses in reports