### PR TITLE
Use unique user_id per ADK agent to prevent session leakage

### DIFF
--- a/src/mcprobe/agents/adk.py
+++ b/src/mcprobe/agents/adk.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import time
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -44,7 +45,8 @@ class GeminiADKAgent(AgentUnderTest):
             session_service=self._session_service,
         )
         self._session_id: str | None = None
-        self._user_id = "mcprobe_user"
+        # Use unique user_id per instance to prevent any ADK-side caching/session leakage
+        self._user_id = f"mcprobe_{uuid.uuid4().hex[:8]}"
 
     @property
     def name(self) -> str:
@@ -175,6 +177,8 @@ class GeminiADKAgent(AgentUnderTest):
         from google.adk.sessions import InMemorySessionService  # noqa: PLC0415
 
         self._session_id = None
+        # Generate new user_id to prevent any ADK-side caching/session leakage
+        self._user_id = f"mcprobe_{uuid.uuid4().hex[:8]}"
         # Create fresh session service
         self._session_service = InMemorySessionService()
         self._runner = Runner(


### PR DESCRIPTION
## Summary

- Generate unique `user_id` for each `GeminiADKAgent` instance and on `reset()` to prevent ADK-side caching or session state leakage between test scenarios

## Problem

Agent responses sometimes contained content from different scenarios (e.g., asked about "Find Phoenix Race" but got tire degradation analysis). Root cause: shared `LlmAgent` singleton + hardcoded `user_id = "mcprobe_user"` allowed ADK session state to leak across scenarios.

## Test plan

- [x] Unit tests pass (260 tests)
- [x] Linting and type checking pass
- [x] Manual testing confirmed cross-contamination no longer occurs